### PR TITLE
docs: add READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Styra TypeScript packages
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+This repository contains Styra-supported Open Source TypeScript packages for use with the [Styra](https://styra.com) products, and [Open Policy Agent (OPA)](https://www.openpolicyagent.org/).
+
+
+## [@styra/opa-react](https://www.npmjs.com/package/@styra/opa-react)
+
+Utilities for using [@styra/opa](https://www.npmjs.com/package/@styra/opa) from React.
+
+
+## Community
+
+For questions, discussions and announcements related to Styra products, services and open-source projects, please join
+the Styra community on [Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/packages/opa-react/README.md
+++ b/packages/opa-react/README.md
@@ -1,3 +1,35 @@
-# opa-react
+# @styra/opa-react
 
-<!-- TODO: add content -->
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![NPM Version](https://img.shields.io/npm/v/%40styra%2Fopa-react?style=flat&color=%2324b6e0)](https://www.npmjs.com/package/@styra/opa-react)
+
+This package contains helpers for using [@styra/opa](https://www.npmjs.com/package/@styra/opa) from React.
+
+The package provides an `useAuthz` hook and a high-level `<Authz>` component.
+
+They are enabled by wrapping your App into `<AuthzProvider>`:
+
+```tsx
+<AuthzProvider sdk={sdk} path="policy" defaultInput={{ user, tenant }}>
+  <Nav />
+  <Outlet />
+</AuthzProvider>
+```
+
+This example provides a previously-configured `sdk` instance (`OPAClient` from `@styra/opa`), a request path, and default input (which is merged with per-call inputs).
+
+They can either be used with a function as child:
+```tsx
+<Authz path={path} input={input} loading={<div>loading</div>}>
+  {(result) => <button disabled={!result}>Press Here</button>}
+</Authz>
+```
+
+Or by providing static children (`<button>Press Here</button>`) and optionally `fallback` JSX elements:
+```tsx
+<Authz path={path} input={input} fallback={<div>unauthorized</div>}>
+  <button>Press Here</button>
+</Authz>
+```
+
+The `useAuthz` hook can be used if you need more low-level control about the authorization call.


### PR DESCRIPTION
These are fairly minimal right now. More is to come later. Notably, the @styra/opa-react should mention that it's distributed as ESM and CommonJS, and how to add it to your local setup.