### PR TITLE
releng: publish @styra/opa to JSR from workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,3 +38,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
         if: steps.changesets.outputs.published == 'true'
+
+      - name: publish @styra/opa to JSR
+        run: npx -w packages/opa jsr publish


### PR DESCRIPTION
https://jsr.io/docs/publishing-packages says that it's safe to run this when the package version has already been published:

> `jsr publish` will not attempt to publish if the version specified in
> your jsr.json file is already published to JSR.