### PR TITLE
opa-react: remove function from <Authz> component

### DIFF
--- a/.changeset/neat-suns-reply.md
+++ b/.changeset/neat-suns-reply.md
@@ -1,0 +1,9 @@
+---
+"@styra/opa-react": minor
+---
+
+Remove function support from <Authz> component
+
+Allowing a function had unintended consequences for performance, given how
+React works. Now, there is only one way to do it: `fallback` for non-truthy
+results, and `children` for truthy results.

--- a/packages/opa-react/src/authz.tsx
+++ b/packages/opa-react/src/authz.tsx
@@ -1,9 +1,9 @@
-import { type ReactNode } from "react";
+import { type ReactNode, type PropsWithChildren } from "react";
 
 import useAuthz from "./use-authz.js";
 import { type Input } from "@styra/opa";
 
-export type AuthzProps = {
+export type AuthzProps = PropsWithChildren<{
   /** Input to the policy evaluation. Will be merged with `AuthzProvider`'s `defaultInput` (if set), overriding it when in conflict. */
   input?: Input;
   /** Path of the policy to evluate. Will default to `AuthzProvider`'s `path`. */
@@ -17,9 +17,7 @@ export type AuthzProps = {
    * Component to display when result is falsey
    */
   fallback?: ReactNode;
-  /** Children node(s) to render, or a function depending on the result of the policy evaluation. */
-  children?: ReactNode | ((result: unknown) => ReactNode);
-};
+}>;
 
 /**
  * Conditionally renders components based on authorization decisions for a specified
@@ -27,14 +25,6 @@ export type AuthzProps = {
  *
  * The simplest use looks like that shown below; just wrap some arbitrary content
  * and specify path and input.
- *
- * @example Using a function mapping the evaluation result to JSX children
- *
- * ```tsx
- * <Authz path={path} input={input}>
- *   {(result) => <Button disabled={!result}>Delete Item</Button>}
- * </Authz>
- * ```
  *
  * @example JSX children with fallback for the "denied" state
  *
@@ -67,10 +57,6 @@ export default ({
 
   if (isLoading) {
     return loading;
-  }
-
-  if (typeof children === "function") {
-    return children(result);
   }
 
   return !!result ? children : fallback;

--- a/packages/opa-react/tests/authz.test.tsx
+++ b/packages/opa-react/tests/authz.test.tsx
@@ -1,15 +1,23 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import Authz from "../src/authz";
 import { Result } from "@styra/opa";
-import { describe, test, expect, vi } from "vitest";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 
 // vi.mock is hoisted--even before the imports (https://vitest.dev/api/vi.html#vi-mock)
 vi.mock("../src/use-authz");
 
-const useAuthzMock = await import("../src/use-authz");
+let useAuthzMock: { default: unknown };
 
 describe("Authz component", () => {
+  beforeEach(async () => {
+    useAuthzMock = await import("../src/use-authz");
+  });
+
+  afterEach(() => {
+    cleanup(); // cleanup DOM after each test
+  });
+
   function setUseAuthzMockResult(result: Result, isLoading: boolean = false) {
     useAuthzMock.default = vi.fn(() =>
       !isLoading
@@ -36,7 +44,7 @@ describe("Authz component", () => {
         setUseAuthzMockResult(true, true); // isLoading
         render(
           <Authz path={path} input={input} loading={<div>loading</div>}>
-            {(result) => <button disabled={!result}>Press Here</button>}
+            <button>Press Here</button>
           </Authz>,
         );
         expect(screen.queryByRole("button")).not.toBeInTheDocument();
@@ -45,24 +53,11 @@ describe("Authz component", () => {
     });
 
     describe("when allowed", () => {
-      test("renders children that depend on result (disabled)", async () => {
+      test("renders children", async () => {
         setUseAuthzMockResult(true);
         render(
           <Authz path={path} input={input}>
-            {(result) => <button disabled={!result}>Press Here</button>}
-          </Authz>,
-        );
-        const button = screen.getByRole("button");
-        expect(button).toBeInTheDocument();
-        expect(button).not.toHaveAttribute("hidden");
-        expect(button).not.toHaveAttribute("disabled");
-      });
-
-      test("renders children that depend on result (hidden)", async () => {
-        setUseAuthzMockResult(true);
-        render(
-          <Authz path={path} input={input}>
-            {(result) => <button hidden={!result}>Press Here</button>}
+            <button>Press Here</button>
           </Authz>,
         );
         const button = screen.getByRole("button");
@@ -72,7 +67,7 @@ describe("Authz component", () => {
       });
 
       test("renders children when result is truthy, ignores fallback", async () => {
-        setUseAuthzMockResult(true);
+        setUseAuthzMockResult({ allowed: "yes" });
         render(
           <Authz path={path} input={input} fallback={<div>unauthorized</div>}>
             <button>Press Here</button>
@@ -102,33 +97,18 @@ describe("Authz component", () => {
     });
 
     describe("when denied", () => {
-      test("hides children that depend on result (hidden)", async () => {
+      test("hides children", async () => {
         setUseAuthzMockResult(false);
         render(
           <Authz path={path} input={input}>
-            {(result) => <button hidden={!result}>Press Here</button>}
+            <button>Press Here</button>
           </Authz>,
         );
-        const button = screen.getByText("Press Here"); // hidden elements can't be access "by role"
-        expect(button).toBeInTheDocument();
-        expect(button).toHaveAttribute("hidden");
-        expect(button).not.toHaveAttribute("disabled");
+        const button = screen.queryByText("Press Here"); // hidden elements can't be access "by role"
+        expect(button).not.toBeInTheDocument();
       });
 
-      test("disables children depending on result (disabled)", async () => {
-        setUseAuthzMockResult(false);
-        render(
-          <Authz path={path} input={input}>
-            {(result) => <button disabled={!result}>Press Here</button>}
-          </Authz>,
-        );
-        const button = screen.getByText("Press Here");
-        expect(button).toBeInTheDocument();
-        expect(button).not.toHaveAttribute("hidden");
-        expect(button).toHaveAttribute("disabled");
-      });
-
-      test("renders fallback when not given function", async () => {
+      test("renders fallback when given", async () => {
         setUseAuthzMockResult(false);
         render(
           <Authz path={path} input={input} fallback={<div>unauthorized</div>}>
@@ -138,40 +118,6 @@ describe("Authz component", () => {
         const button = screen.queryByText("Press Here");
         expect(button).not.toBeInTheDocument();
         expect(screen.getByText("unauthorized")).toBeInTheDocument();
-      });
-
-      test("ignores fallback when given function", async () => {
-        setUseAuthzMockResult(false);
-        render(
-          <Authz path={path} input={input} fallback={<div>unauthorized</div>}>
-            {(result) => <button disabled={!result}>Press Here</button>}
-          </Authz>,
-        );
-        const button = screen.queryByText("Press Here");
-        expect(button).toBeInTheDocument();
-        expect(screen.queryByText("unauthorized")).not.toBeInTheDocument();
-      });
-
-      test("combines disabled and hidden siblings", async () => {
-        setUseAuthzMockResult(false);
-        render(
-          <Authz path={path} input={input}>
-            {(result) => [
-              <button key="start" data-testid="start" hidden={!result}>
-                Start
-              </button>,
-              <button key="stop" data-testid="stop" disabled={!result}>
-                Stop
-              </button>,
-            ]}
-          </Authz>,
-        );
-        const start = screen.getByTestId("start");
-        const stop = screen.getByTestId("stop");
-        expect(start).not.toHaveAttribute("disabled");
-        expect(start).toHaveAttribute("hidden");
-        expect(stop).toHaveAttribute("disabled");
-        expect(stop).not.toHaveAttribute("hidden");
       });
     });
   });


### PR DESCRIPTION
Allowing a function had unintended consequences for performance, given how
React works. Now, there is only one way to do it: `fallback` for non-truthy
results, and `children` for truthy results.