### PR TITLE
dependabot: handle actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,18 +11,7 @@ updates:
           - "eslint-*"
           - "eslint"
           - "prettier"
-  - package-ecosystem: "npm"
-    directory: "packages/opa-react"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
-    groups:
-      eslint:
-        patterns:
-          - "@typescript-eslint/*"
-          - "eslint-*"
-          - "eslint"
-          - "prettier"
-      react:
-        patterns:
-          - "@react/*"
-          - "react*"
+      interval: daily


### PR DESCRIPTION
Also took it off the nested packages.json, it seemed to be picked up anyways. For the SE-generated packasges/opa, we don't want dependabot updates.