### PR TITLE
workflow: deploy typedoc via github's actions

### DIFF
--- a/.github/workflows/docs_manual.yaml
+++ b/.github/workflows/docs_manual.yaml
@@ -3,6 +3,12 @@ name: Docs
 on:
   workflow_dispatch: {}
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  actions: read
+  pages: write
+  id-token: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -14,12 +20,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 21
-      - name: Install Dependencies
+      - name: Install dependencies
         run: npm ci
-      - name: updated GH pages docs
+      - name: Generate docs
         run: npm run docs
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          # Upload entire repository
+          path: docs/
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
using the manual WF first, to switch the automatic one if this one works 🔀 