### PR TITLE
opa-react: fix typescript errors for vite matchers

### DIFF
--- a/packages/opa-react/package.json
+++ b/packages/opa-react/package.json
@@ -29,7 +29,7 @@
     }
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@types/lodash.merge": "^4.6.9",
     "@types/react": ">=18.0.0",

--- a/packages/opa-react/tests/setup.ts
+++ b/packages/opa-react/tests/setup.ts
@@ -1,11 +1,1 @@
-import { expect, afterEach } from "vitest";
-import { cleanup } from "@testing-library/react";
-import "@testing-library/jest-dom";
-import * as matchers from "@testing-library/jest-dom/matchers";
 import "@testing-library/jest-dom/vitest";
-
-expect.extend(matchers);
-
-afterEach(() => {
-  cleanup();
-});

--- a/packages/opa-react/tsconfig.json
+++ b/packages/opa-react/tsconfig.json
@@ -4,6 +4,6 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
-    "types": ["@testing-library/jest-dom"]
+    "types": ["vitest/globals"]
   }
 }


### PR DESCRIPTION
Following the instructions shared here:
https://github.com/testing-library/jest-dom/issues/439#issuecomment-1715184115