### PR TITLE
opa-react: use @tanstack/react-query for caching etc

### DIFF
--- a/.changeset/pink-items-join.md
+++ b/.changeset/pink-items-join.md
@@ -1,0 +1,16 @@
+---
+"@styra/opa-react": minor
+---
+
+Introduce `@tanstack/react-query` for policy evaluation request caching
+
+With this release, multiple uses of `useAuthz` and `<Authz>` with the same inputs no longer unconditionally lead to API requests.
+Using `@tanstack/react-query` underneath, `useAuthz` will now return cached results when applicable.
+
+Furthermore, API requests are retried on transient errors.
+You can control the retry count via `AuthzProvider`'s `retry` property.
+
+**NOTE** The `fromResult` property/argument is currently exempt from the cache key -- so two requests with the same `path` and `input` will produce the same result even if their `fromResult` differs.
+We believe that this is quite uncommon, please file an issue if it is a problem in your use case.
+
+For details on how and when the cache is invalidated, please refer to the docs here: https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults

--- a/.changeset/strong-melons-sip.md
+++ b/.changeset/strong-melons-sip.md
@@ -1,0 +1,9 @@
+---
+"@styra/opa-react": minor
+---
+
+change exported interfaces names
+
+The export iterface `SDK` is now called `OPAClient` for consistency with `@styra/opa`.
+
+It is used in `AuthzProviderContext` and `AuthzProviderProps`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -488,6 +488,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
       "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1751,6 +1752,30 @@
     "node_modules/@styra/opa-react": {
       "resolved": "packages/opa-react",
       "link": true
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.50.1.tgz",
+      "integrity": "sha512-lpfhKPrJlyV2DSVcQb/HuozH3Av3kws4ge22agx+lNGpFkS4vLZ7St0l3GLwlAD+bqB+qXGex3JdRKUNtMviEQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.50.1.tgz",
+      "integrity": "sha512-s0DW3rVBDPReDDovUjVqItVa3R2nPfUANK9nqGvarO2DwTiY9U4EBTsqizMxItRCoGgK5apeM7D3mxlHrSKpdQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.50.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.2.0",
@@ -3581,6 +3606,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7267,7 +7293,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
@@ -8858,22 +8885,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/use-deep-compare-effect": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
-      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "dequal": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9425,8 +9436,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@styra/opa": ">=1.1.3",
+        "@tanstack/react-query": "^5.50.1",
         "lodash.merge": "^4.6.2",
-        "use-deep-compare-effect": "^1.8.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {

--- a/packages/opa-react/package.json
+++ b/packages/opa-react/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "@styra/opa": ">=1.1.3",
+    "@tanstack/react-query": "^5.50.1",
     "lodash.merge": "^4.6.2",
-    "use-deep-compare-effect": "^1.8.1",
     "zod": "^3.23.8"
   },
   "publishConfig": {

--- a/packages/opa-react/src/authz-provider.tsx
+++ b/packages/opa-react/src/authz-provider.tsx
@@ -9,7 +9,7 @@ import {
 import { type ServerError } from "@styra/opa/sdk/models/components";
 
 /** Abstracts the methods that are used from `OPAClient` of `@styra/opa`. */
-export interface SDK {
+export interface OPAClient {
   /** Evaluate a policy at `path`, with optional `input` and `RequestOptions`. */
   evaluate<In extends Input | ToInput, Res>(
     path: string,
@@ -33,7 +33,7 @@ export interface SDK {
 
 export type AuthzProviderContext = {
   /**  The `@styra/opa` OPAClient instance to use. */
-  sdk: SDK;
+  sdk: OPAClient;
   /** Default path for every decision. Override by providing`path`. */
   defaultPath?: string;
   /**  Default input for every decision, merged with any passed-in input. Use the latter to override the defaults. */

--- a/packages/opa-react/tests/authz.test.tsx
+++ b/packages/opa-react/tests/authz.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import Authz from "../src/authz";
 import { Result } from "@styra/opa";

--- a/packages/opa-react/tests/use-authz.test.tsx
+++ b/packages/opa-react/tests/use-authz.test.tsx
@@ -1,8 +1,10 @@
-import React from "react";
 import { renderHook, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { OPAClient, type Result } from "@styra/opa";
-import AuthzProvider, { AuthzProviderProps } from "../src/authz-provider";
+import {
+  default as AuthzProvider,
+  AuthzProviderProps,
+} from "../src/authz-provider";
 import useAuthz from "../src/use-authz";
 
 describe("useAuthz Hook", () => {
@@ -14,18 +16,21 @@ describe("useAuthz Hook", () => {
     defaultPath,
     defaultInput,
     defaultFromResult,
-  }: Omit<AuthzProviderProps, "sdk"> = {}) => ({
-    wrapper: ({ children }) => (
-      <AuthzProvider
-        sdk={opa}
-        defaultPath={defaultPath}
-        defaultInput={defaultInput}
-        defaultFromResult={defaultFromResult}
-      >
-        {children}
-      </AuthzProvider>
-    ),
-  });
+  }: Omit<AuthzProviderProps, "sdk" | "queryClient" | "retry"> = {}) => {
+    return {
+      wrapper: ({ children }) => (
+        <AuthzProvider
+          sdk={opa}
+          defaultPath={defaultPath}
+          defaultInput={defaultInput}
+          defaultFromResult={defaultFromResult}
+          retry={false}
+        >
+          {children}
+        </AuthzProvider>
+      ),
+    };
+  };
 
   describe("on error", () => {
     it("sets the error", async () => {

--- a/packages/opa-react/tsconfig.json
+++ b/packages/opa-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
With this change, all of the heavy lifting done in `useAuthz` is taken over by `useQuery` from `@tanstack/react-query`.

The queryClient is added to AuthzContext, so we're not trampling over any of our users' usage of `react-query` via QueryClientProvider.

Note: the `fromResult` function is not part of the cache key -- so changing that function at runtime could yield to surprising results. However, I think it's unlikely to be an issue in real world usage; I have yet to see a use case where `fromResult` changes frequently.

TODOs:
- [ ] add cache-exercising test cases
- [x] tweak types (see TODO comments)
- [x] document `fromResult` restriction
- [x] add changeset for the new feature