### PR TITLE
opa-react: useMemo, not useState

### DIFF
--- a/.changeset/strong-melons-sip.md
+++ b/.changeset/strong-melons-sip.md
@@ -2,8 +2,8 @@
 "@styra/opa-react": minor
 ---
 
-change exported interfaces names
+change exported interfaces names, and AuthzProvider property
 
 The export iterface `SDK` is now called `OPAClient` for consistency with `@styra/opa`.
 
-It is used in `AuthzProviderContext` and `AuthzProviderProps`.
+It is used in `AuthzProviderContext` and `AuthzProviderProps`, and has been renamed from `sdk` to `opaClient`.

--- a/packages/opa-react/README.md
+++ b/packages/opa-react/README.md
@@ -10,13 +10,13 @@ The package provides an `useAuthz` hook and a high-level `<Authz>` component.
 They are enabled by wrapping your App into `<AuthzProvider>`:
 
 ```tsx
-<AuthzProvider sdk={sdk} defaultPath="policy" defaultInput={{ user, tenant }}>
+<AuthzProvider opaClient={opaClient} defaultPath="policy" defaultInput={{ user, tenant }}>
   <Nav />
   <Outlet />
 </AuthzProvider>
 ```
 
-This example provides a previously-configured `sdk` instance (`OPAClient` from `@styra/opa`), a request path, and default input (which is merged with per-call inputs).
+This example provides a previously-configured `opaClient` instance (`OPAClient` from `@styra/opa`), a request path, and default input (which is merged with per-call inputs).
 
 They can either be used by providing static children (`<button>Press Here</button>`) and optionally `fallback` and `loading` JSX elements:
 ```tsx

--- a/packages/opa-react/src/authz-provider.tsx
+++ b/packages/opa-react/src/authz-provider.tsx
@@ -1,9 +1,4 @@
-import {
-  type PropsWithChildren,
-  createContext,
-  useState,
-  useMemo,
-} from "react";
+import { type PropsWithChildren, createContext, useMemo } from "react";
 import { QueryClient, QueryFunctionContext } from "@tanstack/react-query";
 import {
   type Input,
@@ -87,7 +82,9 @@ export default function AuthzProvider({
   defaultFromResult,
   retry = 3,
 }: AuthzProviderProps) {
-  const [queryClient] = useState(() => {
+  const queryClient = useMemo(() => {
+    if (!sdk) return;
+
     const defaultQueryFn = async ({
       queryKey,
       meta = {},
@@ -113,7 +110,7 @@ export default function AuthzProvider({
         },
       },
     });
-  });
+  }, [sdk]);
 
   const context = useMemo<AuthzProviderContext>(
     () => ({
@@ -121,11 +118,13 @@ export default function AuthzProvider({
       defaultPath,
       defaultInput,
       defaultFromResult,
-      queryClient,
+      queryClient: queryClient as QueryClient,
       retry,
     }),
     [sdk, defaultPath, defaultInput, defaultFromResult, queryClient, retry],
   );
+
+  if (!queryClient) return null;
 
   return (
     <AuthzContext.Provider value={context}>{children}</AuthzContext.Provider>

--- a/packages/opa-react/tests/authz.test.tsx
+++ b/packages/opa-react/tests/authz.test.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import Authz from "../src/authz";
 import { Result } from "@styra/opa";

--- a/packages/opa-react/tests/use-authz.test.tsx
+++ b/packages/opa-react/tests/use-authz.test.tsx
@@ -16,11 +16,11 @@ describe("useAuthz Hook", () => {
     defaultPath,
     defaultInput,
     defaultFromResult,
-  }: Omit<AuthzProviderProps, "sdk" | "queryClient" | "retry"> = {}) => {
+  }: Omit<AuthzProviderProps, "opaClient" | "queryClient" | "retry"> = {}) => {
     return {
       wrapper: ({ children }) => (
         <AuthzProvider
-          sdk={opa}
+          opaClient={opa}
           defaultPath={defaultPath}
           defaultInput={defaultInput}
           defaultFromResult={defaultFromResult}


### PR DESCRIPTION
In tickethub, the previous approach gave us failures because `sdk` was unset. I think this means our tests setup is having gaps.