### PR TITLE
opa-react: introduce batching

### DIFF
--- a/.changeset/cold-bikes-sit.md
+++ b/.changeset/cold-bikes-sit.md
@@ -1,0 +1,22 @@
+---
+"@styra/opa-react": minor
+---
+
+Support batching requests sent to the backend (optional)
+
+When used with [Enterprise OPA's Batch API](https://docs.styra.com/enterprise-opa/reference/api-reference/batch-api), this mode allows for sending much
+fewer requests to the backend. It's enabled by setting `batch={true}` on `<AuthzProvider>`.
+
+Note that the Batch API has no notion of "default query", so it's not possible
+to use batching without having either `defaultPath` (`<AuthzProvider>`) or
+`path` (`useAuthz()`, `<Authz>`) set.
+
+Please note that `fromResult` is exempt from the cache key, so multiple requests
+with the same path and input, but different `fromResult` settings will lead to
+unforeseen results.
+This is on par with the regular (non-batching) caching, and we'll revisit this
+if it becomes a problem for users. Please create an issue on Github if it is
+problematic for you.
+
+Furthermore, batching queries are not wired up with `AbortController` like the
+non-batching equivalents are.

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -70,7 +70,7 @@ jobs:
         run: npx -w ${{ matrix.pkg }} attw --pack --ignore-rules no-resolution
         if: matrix.pkg == 'packages/opa'
       - name: jsr publish dry-run
-        run: npx -w ${{ matrix.pkg }} jsr publish --dry-run
+        run: npx -w ${{ matrix.pkg }} jsr publish --dry-run --allow-dirty
         if: matrix.pkg == 'packages/opa'
 
   success:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2471,20 +2471,6 @@
       "integrity": "sha512-AyttV1Njj5ug+XqEWY1smV45dTWMlWKtj1B8jcFYgBKUFyUlF/qEhD+iP1E5UaRYW6hQRYD9T2WNDwFTrOMWzQ==",
       "license": "MIT"
     },
-    "node_modules/@yornaath/batshit-devtools-react": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@yornaath/batshit-devtools-react/-/batshit-devtools-react-0.8.1.tgz",
-      "integrity": "sha512-Qg1ZFFkZD/7kko6iPFLP01TpOhLXjjg6tJmPeEOv6m20FGa+MLHnmJFnbyXd0z0YNMzF8LJghwRIhfO++FjRwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@yornaath/batshit": "*",
-        "@yornaath/batshit-devtools": "*",
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
@@ -6057,12 +6043,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
-    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -9473,7 +9453,6 @@
         "@styra/opa": ">=1.1.3",
         "@tanstack/react-query": "^5.50.1",
         "@yornaath/batshit": "^0.10.1",
-        "@yornaath/batshit-devtools-react": "^0.8.1",
         "lodash.merge": "^4.6.2",
         "zod": "^3.23.8"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2456,6 +2456,35 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
+    "node_modules/@yornaath/batshit": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@yornaath/batshit/-/batshit-0.10.1.tgz",
+      "integrity": "sha512-WGZ1WNoiVN6CLf28O73+6SCf+2lUn4U7TLGM9f4zOad0pn9mdoXIq8cwu3Kpf7N2OTYgWGK4eQPTflwFlduDGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@yornaath/batshit-devtools": "^1.7.1"
+      }
+    },
+    "node_modules/@yornaath/batshit-devtools": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@yornaath/batshit-devtools/-/batshit-devtools-1.7.1.tgz",
+      "integrity": "sha512-AyttV1Njj5ug+XqEWY1smV45dTWMlWKtj1B8jcFYgBKUFyUlF/qEhD+iP1E5UaRYW6hQRYD9T2WNDwFTrOMWzQ==",
+      "license": "MIT"
+    },
+    "node_modules/@yornaath/batshit-devtools-react": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@yornaath/batshit-devtools-react/-/batshit-devtools-react-0.8.1.tgz",
+      "integrity": "sha512-Qg1ZFFkZD/7kko6iPFLP01TpOhLXjjg6tJmPeEOv6m20FGa+MLHnmJFnbyXd0z0YNMzF8LJghwRIhfO++FjRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@yornaath/batshit": "*",
+        "@yornaath/batshit-devtools": "*",
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
@@ -6028,6 +6057,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -9437,6 +9472,8 @@
       "dependencies": {
         "@styra/opa": ">=1.1.3",
         "@tanstack/react-query": "^5.50.1",
+        "@yornaath/batshit": "^0.10.1",
+        "@yornaath/batshit-devtools-react": "^0.8.1",
         "lodash.merge": "^4.6.2",
         "zod": "^3.23.8"
       },

--- a/packages/opa-react/package.json
+++ b/packages/opa-react/package.json
@@ -40,7 +40,6 @@
     "@styra/opa": ">=1.1.3",
     "@tanstack/react-query": "^5.50.1",
     "@yornaath/batshit": "^0.10.1",
-    "@yornaath/batshit-devtools-react": "^0.8.1",
     "lodash.merge": "^4.6.2",
     "zod": "^3.23.8"
   },

--- a/packages/opa-react/package.json
+++ b/packages/opa-react/package.json
@@ -39,6 +39,8 @@
   "dependencies": {
     "@styra/opa": ">=1.1.3",
     "@tanstack/react-query": "^5.50.1",
+    "@yornaath/batshit": "^0.10.1",
+    "@yornaath/batshit-devtools-react": "^0.8.1",
     "lodash.merge": "^4.6.2",
     "zod": "^3.23.8"
   },

--- a/packages/opa-react/src/package.json
+++ b/packages/opa-react/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/opa-react/src/use-authz.ts
+++ b/packages/opa-react/src/use-authz.ts
@@ -37,7 +37,6 @@ export default function useAuthz(
   const i = mergeInput(input, defaultInput);
   const fromR = fromResult ?? defaultFromResult;
 
-  // console.log({ p, i });
   const {
     // NOTE(sr): we're ignoring 'status'
     data: result,

--- a/packages/opa-react/src/use-authz.ts
+++ b/packages/opa-react/src/use-authz.ts
@@ -26,11 +26,18 @@ export default function useAuthz(
   if (context === undefined) {
     throw Error("Authz/useAuthz can only be used inside an AuthzProvider");
   }
-  const { defaultPath, defaultInput, defaultFromResult, queryClient } = context;
+  const {
+    defaultPath,
+    defaultInput,
+    defaultFromResult,
+    queryClient,
+    opaClient,
+  } = context;
   const p = path ?? defaultPath;
   const i = mergeInput(input, defaultInput);
   const fromR = fromResult ?? defaultFromResult;
 
+  // console.log({ p, i });
   const {
     // NOTE(sr): we're ignoring 'status'
     data: result,
@@ -40,6 +47,7 @@ export default function useAuthz(
     {
       queryKey: [p, i],
       meta: { fromResult: fromR },
+      enabled: !!opaClient,
     },
     queryClient,
   );

--- a/packages/opa-react/tsconfig.json
+++ b/packages/opa-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ESNext.Object", "DOM"],
     "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx",
     "declaration": true,


### PR DESCRIPTION
This change introduces **batching** as an option for `@styra/opa-react`.

It is enabled by passing `batch={true}` to `<AuthzProvider>` and will cause multiple calls to `useAuthz` or usages of `<Authz>` to be combined into groups of batch requests.

It is only applicable when using Enterprise OPA (which has a [Batch API](https://docs.styra.com/enterprise-opa/reference/api-reference/batch-api)), or when implementing a compatible API yourself.

Notes:
1. `fromResult` is exempt from caching (same as with the non-batching cache feature): `{path: "foo", input: {user: "alice"}, fromResult: (x) => x.foo}` and `{path: "foo", input: {user: "alice"}, fromResult: (x) => x.bar}` **yield the same result** (which one is undefined), so this should **be avoided**.
2. The batch feature doesn't support query cancellation via `signal` (`AbortController`), the non-batching querier does.
3. Some props fields have been removed from `AuthzContext`, since only a subset of the `AuthzProviderProps` are useful from the hooks etc. It's a general cleanup: you can **set** `retry` and `batch` on `AuthzProvider`, but those will be used to create the `queryClient` that's employed in `useAuthz`, so only `queryClient` (and not `retry` and `batch`) is retrievable from `AuthzContext`.

<details><summary>Previous notes</summary>

Lots of TODOs and debug logs. It seems to generally work, but

1. I'm losing the ticket/allow request with action: create for
   the "New Ticket" button in tickethub. That can't be right.
4. Tests, docs.
5. The hash function is ridiculous, I've been using `JSON.stringify`
   because I couldn't get the stable-hash import to work in any
   way.
6. fromResult and signal aren't handled at all.
------

Updates:
- (1.) is resolved, we had been missing an `opaClient` when the first request was sent. Using the `enabled` field for this in react-query now.
- (4.) I think handling signal is just not supported. ([But I've asked the author to verify.](https://github.com/yornaath/batshit/issues/17)) We'll need to decide between query cancellation without batching or batching without query cancellation, I suppose.
- (4.) I've added `fromResult` handling. We'll need to test this rigorously! ⚠️ 
- (3.) we're using a different hash function now. It's probably not sufficient, though -- Input needs to basically be JSON, but it might not be JSON when we feed it to the `@styra/opa` OPAClient -- _That_ takes care of making it JSON, but it  might not be when we receive it here. 🤔 This needs some more work.
</details>