### PR TITLE
opa-react: ignore src/package.json

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -70,7 +70,7 @@ jobs:
         run: npx -w ${{ matrix.pkg }} attw --pack --ignore-rules no-resolution
         if: matrix.pkg == 'packages/opa'
       - name: jsr publish dry-run
-        run: npx -w ${{ matrix.pkg }} jsr publish --dry-run --allow-dirty
+        run: npx -w ${{ matrix.pkg }} jsr publish --dry-run
         if: matrix.pkg == 'packages/opa'
 
   success:

--- a/packages/opa-react/.gitignore
+++ b/packages/opa-react/.gitignore
@@ -1,2 +1,3 @@
 /.tshy
 /.tshy-*
+/src/package.json

--- a/packages/opa-react/src/package.json
+++ b/packages/opa-react/src/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}


### PR DESCRIPTION
I believe tshy creates that, and it trips up JSR.