### PR TITLE
opa-react: performance improvement, test addition

### DIFF
--- a/packages/opa-react/src/authz-provider.tsx
+++ b/packages/opa-react/src/authz-provider.tsx
@@ -50,7 +50,7 @@ const evals = (sdk: OPAClient) =>
               ),
             );
         }),
-      ).then((all: object[]) => all.reduce((acc, n) => ({ ...acc, ...n }), {})); // combine result arrays of objects
+      ).then((all: object[]) => Object.assign({}, ...all)); // combine result arrays of objects
     },
     resolver: (results, query) => results[key(query)] ?? null,
     scheduler: windowScheduler(10),


### PR DESCRIPTION
The previous combine call really created a ton of intermediary objects. All things being equal, I think `Object.assign` should be the better choice here.