### PR TITLE
opa-react: add special case for all-same-path batches

### DIFF
--- a/packages/opa-react/src/authz-provider.tsx
+++ b/packages/opa-react/src/authz-provider.tsx
@@ -50,7 +50,10 @@ const evals = (sdk: OPAClient) =>
               ),
             );
         }),
-      ).then((all: object[]) => Object.assign({}, ...all)); // combine result arrays of objects
+      ).then((all: object[]) =>
+        // combine result arrays of objects (if there's more than one)
+        all.length == 1 ? all[0] : Object.assign({}, ...all),
+      );
     },
     resolver: (results, query) => results[key(query)] ?? null,
     scheduler: windowScheduler(10),


### PR DESCRIPTION
If there's only one type of path, we'll not have to do multiple evaluateBatch() calls, and the result of Promise.all should be an array of 1 object -- the result batch. We don't need to copy its properties into `{}`, we can return it as-is.