### PR TITLE
opa-react: allow `useAuthz` with dynamic queries

### DIFF
--- a/.changeset/healthy-forks-run.md
+++ b/.changeset/healthy-forks-run.md
@@ -1,0 +1,17 @@
+---
+"@styra/opa-react": minor
+---
+
+Let `useAuthz` handle multiple queries at once
+
+If you don't know the number of evaluations you need, or if you want to do evaluations in a loop, you cannot do that with the "single-decision" `useAuthz` call.
+
+So now, you can provide an array of evaluation queries,
+```ts
+{
+    path?: string;
+    input?: Input;
+    fromResult?: (_?: Result) => boolean;
+  }[],
+```
+instead, and you'll get a `UseAuthzResult<T>[]` in return.

--- a/packages/opa-react/src/index.ts
+++ b/packages/opa-react/src/index.ts
@@ -2,5 +2,5 @@ export { default as Authz } from "./authz.js";
 export type * from "./authz.js";
 export { default as AuthzProvider, AuthzContext } from "./authz-provider.js";
 export type * from "./authz-provider.js";
-export { default as useAuthz, useAuthzMultiple } from "./use-authz.js";
+export { default as useAuthz } from "./use-authz.js";
 export type * from "./use-authz.js";

--- a/packages/opa-react/src/index.ts
+++ b/packages/opa-react/src/index.ts
@@ -2,5 +2,5 @@ export { default as Authz } from "./authz.js";
 export type * from "./authz.js";
 export { default as AuthzProvider, AuthzContext } from "./authz-provider.js";
 export type * from "./authz-provider.js";
-export { default as useAuthz } from "./use-authz.js";
+export { default as useAuthz, useAuthzMultiple } from "./use-authz.js";
 export type * from "./use-authz.js";

--- a/packages/opa-react/tests/use-authz.test.tsx
+++ b/packages/opa-react/tests/use-authz.test.tsx
@@ -51,260 +51,349 @@ describe("useAuthz Hook", () => {
       );
       expect(evaluateSpy).toHaveBeenCalledWith(undefined, expect.anything());
     });
-  });
 
-  describe("on success", () => {
-    it("works without any path and input", async () => {
-      const evaluateSpy = vi
-        .spyOn(opa, "evaluateDefault")
-        .mockResolvedValue(false);
+    describe("on success", () => {
+      it("works without any path and input", async () => {
+        const evaluateSpy = vi
+          .spyOn(opa, "evaluateDefault")
+          .mockResolvedValue(false);
 
-      const { result } = renderHook(() => useAuthz(), wrapper());
-      await waitFor(() =>
-        expect(result.current).toMatchObject({
-          isLoading: false,
-          error: undefined,
-          result: false,
-        }),
-      );
-      expect(evaluateSpy).toHaveBeenCalledWith(undefined, expect.anything());
-    });
+        const { result } = renderHook(() => useAuthz(), wrapper());
+        await waitFor(() =>
+          expect(result.current).toMatchObject({
+            isLoading: false,
+            error: undefined,
+            result: false,
+          }),
+        );
+        expect(evaluateSpy).toHaveBeenCalledWith(undefined, expect.anything());
+      });
 
-    it("works with provider path and without input", async () => {
-      const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
+      it("works with provider path and without input", async () => {
+        const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
 
-      const { result } = renderHook(
-        () => useAuthz(),
-        wrapper({ defaultPath: "some/rule" }),
-      );
-      await waitFor(() =>
-        expect(result.current).toMatchObject({
-          isLoading: false,
-          error: undefined,
-          result: false,
-        }),
-      );
-      expect(evaluateSpy).toHaveBeenCalledWith(
-        "some/rule",
-        undefined /* input */,
-        expect.anything(),
-      );
-    });
+        const { result } = renderHook(
+          () => useAuthz(),
+          wrapper({ defaultPath: "some/rule" }),
+        );
+        await waitFor(() =>
+          expect(result.current).toMatchObject({
+            isLoading: false,
+            error: undefined,
+            result: false,
+          }),
+        );
+        expect(evaluateSpy).toHaveBeenCalledWith(
+          "some/rule",
+          undefined /* input */,
+          expect.anything(),
+        );
+      });
 
-    it("works without any path and input, with fromResult from provider prop", async () => {
-      const evaluateSpy = vi
-        .spyOn(opa, "evaluateDefault")
-        .mockResolvedValue(false);
+      it("works without any path and input, with fromResult from provider prop", async () => {
+        const evaluateSpy = vi
+          .spyOn(opa, "evaluateDefault")
+          .mockResolvedValue(false);
 
-      const defaultFromResult = (r?: Result): boolean =>
-        ((r as Record<string, any>)["foobar"] as boolean) ?? false;
+        const defaultFromResult = (r?: Result): boolean =>
+          ((r as Record<string, any>)["foobar"] as boolean) ?? false;
 
-      const { result } = renderHook(
-        () => useAuthz(),
-        wrapper({ defaultFromResult }),
-      );
-      await waitFor(() =>
-        expect(result.current).toMatchObject({
-          isLoading: false,
-          error: undefined,
-          result: false,
-        }),
-      );
-      expect(evaluateSpy).toHaveBeenCalledWith(undefined, {
-        fetchOptions: expect.anything(),
-        fromResult: defaultFromResult,
+        const { result } = renderHook(
+          () => useAuthz(),
+          wrapper({ defaultFromResult }),
+        );
+        await waitFor(() =>
+          expect(result.current).toMatchObject({
+            isLoading: false,
+            error: undefined,
+            result: false,
+          }),
+        );
+        expect(evaluateSpy).toHaveBeenCalledWith(undefined, {
+          fetchOptions: expect.anything(),
+          fromResult: defaultFromResult,
+        });
+      });
+
+      it("works with path and input, with fromResult from provider prop", async () => {
+        const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
+
+        const defaultFromResult = (r?: Result): boolean =>
+          ((r as Record<string, any>)["foobar"] as boolean) ?? false;
+
+        const { result } = renderHook(
+          () => useAuthz(),
+          wrapper({
+            defaultFromResult,
+            defaultPath: "some/thing",
+            defaultInput: { x: true },
+          }),
+        );
+        await waitFor(() =>
+          expect(result.current).toMatchObject({
+            isLoading: false,
+            error: undefined,
+            result: false,
+          }),
+        );
+        expect(evaluateSpy).toHaveBeenCalledWith(
+          "some/thing",
+          { x: true },
+          {
+            fetchOptions: expect.anything(),
+            fromResult: defaultFromResult,
+          },
+        );
+      });
+
+      it("works with path and input, with authz fromResult overriding provider props", async () => {
+        const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
+
+        const defaultFromResult = (r?: Result): boolean =>
+          ((r as Record<string, any>)["foobar"] as boolean) ?? false;
+        const defaultFromResult2 = (r?: Result): boolean => true;
+
+        const { result } = renderHook(
+          () => useAuthz("some/thing/else", { y: "z" }, defaultFromResult2),
+          wrapper({
+            defaultFromResult,
+            defaultPath: "some/thing",
+            defaultInput: { x: true },
+          }),
+        );
+        await waitFor(() =>
+          expect(result.current).toMatchObject({
+            isLoading: false,
+            error: undefined,
+            result: false,
+          }),
+        );
+        expect(evaluateSpy).toHaveBeenCalledWith(
+          "some/thing/else",
+          { x: true, y: "z" },
+          {
+            fetchOptions: expect.anything(),
+            fromResult: defaultFromResult2,
+          },
+        );
+      });
+
+      it("works with provider and call path (call path overrides provider path)", async () => {
+        const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
+
+        const { result } = renderHook(
+          () => useAuthz("some/other/path"),
+          wrapper({ defaultPath: "some/provider/path" }),
+        );
+        await waitFor(() =>
+          expect(result.current).toMatchObject({
+            isLoading: false,
+            error: undefined,
+            result: false,
+          }),
+        );
+        expect(evaluateSpy).toHaveBeenCalledWith(
+          "some/other/path",
+          undefined /* input */,
+          expect.anything(),
+        );
+      });
+
+      it("works with provider path and default input", async () => {
+        const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
+
+        const { result } = renderHook(
+          () => useAuthz(),
+          wrapper({ defaultPath: "some/rule", defaultInput: { x: "default" } }),
+        );
+        await waitFor(() =>
+          expect(result.current).toMatchObject({
+            isLoading: false,
+            error: undefined,
+            result: false,
+          }),
+        );
+        expect(evaluateSpy).toHaveBeenCalledWith(
+          "some/rule",
+          { x: "default" },
+          expect.anything(),
+        );
+      });
+
+      it("works with provider path and call input", async () => {
+        const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
+
+        const { result } = renderHook(
+          () => useAuthz("some/other/path", { other: "input" }),
+          wrapper({ defaultPath: "some/provider/path" }),
+        );
+        await waitFor(() =>
+          expect(result.current).toMatchObject({
+            isLoading: false,
+            error: undefined,
+            result: false,
+          }),
+        );
+        expect(evaluateSpy).toHaveBeenCalledWith(
+          "some/other/path",
+          { other: "input" },
+          expect.anything(),
+        );
+      });
+
+      it("works with provider path and default+call input (merging)", async () => {
+        const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
+
+        const { result } = renderHook(
+          () => useAuthz("some/other/path", { other: "input" }),
+          wrapper({
+            defaultPath: "some/provider/path",
+            defaultInput: { x: "default" },
+          }),
+        );
+        await waitFor(() =>
+          expect(result.current).toMatchObject({
+            isLoading: false,
+            error: undefined,
+            result: false,
+          }),
+        );
+        expect(evaluateSpy).toHaveBeenCalledWith(
+          "some/other/path",
+          { x: "default", other: "input" },
+          expect.anything(),
+        );
+      });
+
+      it("caches requests with the same input/path (disregarding fromResult)", async () => {
+        // NOTE(sr): We're mocking the call to evaluate which handles the `fromResult`
+        // application. So, it never really is called. However, we check that it was
+        // passed as expected in the assertions below.
+        const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
+
+        const fromResult1 = (res?: Result) => (res as any).foo;
+        const fromResult2 = (res?: Result) => (res as any).bar;
+
+        const { result } = renderHook(() => {
+          return {
+            first: useAuthz("path/allow", "foo", fromResult1),
+            second: useAuthz(
+              "path/allow",
+              "foo",
+              fromResult2, // Not part of the cache key!
+            ),
+          };
+        }, wrapper());
+
+        await waitFor(() =>
+          Promise.all([
+            expect(result.current.first).toMatchObject({
+              isLoading: false,
+              error: undefined,
+              result: false,
+            }),
+            expect(result.current.second).toMatchObject({
+              isLoading: false,
+              error: undefined,
+              result: false,
+            }),
+          ]),
+        );
+
+        expect(evaluateSpy).toHaveBeenCalledOnce();
+        expect(evaluateSpy).toHaveBeenCalledWith("path/allow", "foo", {
+          fetchOptions: expect.anything(),
+          fromResult: fromResult1,
+        });
       });
     });
 
-    it("works with path and input, with fromResult from provider prop", async () => {
-      const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
+    describe("with multiple queries", () => {
+      describe("on error", () => {
+        it("sets the error accordingly", async () => {
+          const error = new Error("error");
+          const evaluateSpy = vi
+            .spyOn(opa, "evaluateDefault")
+            .mockRejectedValueOnce(error)
+            .mockResolvedValueOnce(false);
 
-      const defaultFromResult = (r?: Result): boolean =>
-        ((r as Record<string, any>)["foobar"] as boolean) ?? false;
+          const in1 = { a: "foo" };
+          const in2 = { b: "bar" };
+          const { result } = renderHook(
+            () => useAuthz([{ input: in1 }, { input: in2 }]),
+            wrapper(),
+          );
+          await waitFor(() =>
+            expect(result.current).toMatchObject([
+              {
+                isLoading: false,
+                error,
+                result: undefined,
+              },
+              {
+                isLoading: false,
+                error: undefined,
+                result: false,
+              },
+            ]),
+          );
+          expect(evaluateSpy).toHaveBeenCalledTimes(2);
+          expect(evaluateSpy).toHaveBeenNthCalledWith(
+            1,
+            in1,
+            expect.anything(),
+          );
+          expect(evaluateSpy).toHaveBeenNthCalledWith(
+            2,
+            in2,
+            expect.anything(),
+          );
+        });
+      });
 
-      const { result } = renderHook(
-        () => useAuthz(),
-        wrapper({
-          defaultFromResult,
-          defaultPath: "some/thing",
-          defaultInput: { x: true },
-        }),
-      );
-      await waitFor(() =>
-        expect(result.current).toMatchObject({
-          isLoading: false,
-          error: undefined,
-          result: false,
-        }),
-      );
-      expect(evaluateSpy).toHaveBeenCalledWith(
-        "some/thing",
-        { x: true },
-        {
-          fetchOptions: expect.anything(),
-          fromResult: defaultFromResult,
-        },
-      );
-    });
+      describe("on success", () => {
+        it("works with default path+input from provider", async () => {
+          const evaluateSpy = vi
+            .spyOn(opa, "evaluate")
+            .mockResolvedValue(false);
 
-    it("works with path and input, with authz fromResult overriding provider props", async () => {
-      const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
-
-      const defaultFromResult = (r?: Result): boolean =>
-        ((r as Record<string, any>)["foobar"] as boolean) ?? false;
-      const defaultFromResult2 = (r?: Result): boolean => true;
-
-      const { result } = renderHook(
-        () => useAuthz("some/thing/else", { y: "z" }, defaultFromResult2),
-        wrapper({
-          defaultFromResult,
-          defaultPath: "some/thing",
-          defaultInput: { x: true },
-        }),
-      );
-      await waitFor(() =>
-        expect(result.current).toMatchObject({
-          isLoading: false,
-          error: undefined,
-          result: false,
-        }),
-      );
-      expect(evaluateSpy).toHaveBeenCalledWith(
-        "some/thing/else",
-        { x: true, y: "z" },
-        {
-          fetchOptions: expect.anything(),
-          fromResult: defaultFromResult2,
-        },
-      );
-    });
-
-    it("works with provider and call path (call path overrides provider path)", async () => {
-      const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
-
-      const { result } = renderHook(
-        () => useAuthz("some/other/path"),
-        wrapper({ defaultPath: "some/provider/path" }),
-      );
-      await waitFor(() =>
-        expect(result.current).toMatchObject({
-          isLoading: false,
-          error: undefined,
-          result: false,
-        }),
-      );
-      expect(evaluateSpy).toHaveBeenCalledWith(
-        "some/other/path",
-        undefined /* input */,
-        expect.anything(),
-      );
-    });
-
-    it("works with provider path and default input", async () => {
-      const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
-
-      const { result } = renderHook(
-        () => useAuthz(),
-        wrapper({ defaultPath: "some/rule", defaultInput: { x: "default" } }),
-      );
-      await waitFor(() =>
-        expect(result.current).toMatchObject({
-          isLoading: false,
-          error: undefined,
-          result: false,
-        }),
-      );
-      expect(evaluateSpy).toHaveBeenCalledWith(
-        "some/rule",
-        { x: "default" },
-        expect.anything(),
-      );
-    });
-
-    it("works with provider path and call input", async () => {
-      const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
-
-      const { result } = renderHook(
-        () => useAuthz("some/other/path", { other: "input" }),
-        wrapper({ defaultPath: "some/provider/path" }),
-      );
-      await waitFor(() =>
-        expect(result.current).toMatchObject({
-          isLoading: false,
-          error: undefined,
-          result: false,
-        }),
-      );
-      expect(evaluateSpy).toHaveBeenCalledWith(
-        "some/other/path",
-        { other: "input" },
-        expect.anything(),
-      );
-    });
-
-    it("works with provider path and default+call input (merging)", async () => {
-      const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
-
-      const { result } = renderHook(
-        () => useAuthz("some/other/path", { other: "input" }),
-        wrapper({
-          defaultPath: "some/provider/path",
-          defaultInput: { x: "default" },
-        }),
-      );
-      await waitFor(() =>
-        expect(result.current).toMatchObject({
-          isLoading: false,
-          error: undefined,
-          result: false,
-        }),
-      );
-      expect(evaluateSpy).toHaveBeenCalledWith(
-        "some/other/path",
-        { x: "default", other: "input" },
-        expect.anything(),
-      );
-    });
-
-    it("caches requests with the same input/path (disregarding fromResult)", async () => {
-      // NOTE(sr): We're mocking the call to evaluate which handles the `fromResult`
-      // application. So, it never really is called. However, we check that it was
-      // passed as expected in the assertions below.
-      const evaluateSpy = vi.spyOn(opa, "evaluate").mockResolvedValue(false);
-
-      const fromResult1 = (res?: Result) => (res as any).foo;
-      const fromResult2 = (res?: Result) => (res as any).bar;
-
-      const { result } = renderHook(() => {
-        return {
-          first: useAuthz("path/allow", "foo", fromResult1),
-          second: useAuthz(
-            "path/allow",
-            "foo",
-            fromResult2, // Not part of the cache key!
-          ),
-        };
-      }, wrapper());
-
-      await waitFor(() =>
-        Promise.all([
-          expect(result.current.first).toMatchObject({
-            isLoading: false,
-            error: undefined,
-            result: false,
-          }),
-          expect(result.current.second).toMatchObject({
-            isLoading: false,
-            error: undefined,
-            result: false,
-          }),
-        ]),
-      );
-
-      expect(evaluateSpy).toHaveBeenCalledOnce();
-      expect(evaluateSpy).toHaveBeenCalledWith("path/allow", "foo", {
-        fetchOptions: expect.anything(),
-        fromResult: fromResult1,
+          const in1 = { a: "foo" };
+          const in2 = { b: "bar" };
+          const { result } = renderHook(
+            () => useAuthz([{ input: in1 }, { input: in2 }]),
+            wrapper({
+              defaultPath: "def/ault",
+              defaultInput: { user: "alice" },
+            }),
+          );
+          await waitFor(() =>
+            expect(result.current).toMatchObject([
+              {
+                isLoading: false,
+                error: undefined,
+                result: false,
+              },
+              {
+                isLoading: false,
+                error: undefined,
+                result: false,
+              },
+            ]),
+          );
+          expect(evaluateSpy).toHaveBeenCalledTimes(2);
+          expect(evaluateSpy).toHaveBeenNthCalledWith(
+            1,
+            "def/ault",
+            { user: "alice", ...in1 },
+            expect.anything(),
+          );
+          expect(evaluateSpy).toHaveBeenNthCalledWith(
+            2,
+            "def/ault",
+            { user: "alice", ...in2 },
+            expect.anything(),
+          );
+        });
       });
     });
   });
@@ -553,6 +642,86 @@ describe("useAuthz Hook", () => {
         { [hash]: "foo" },
         { rejectMixed: true },
       );
+    });
+
+    describe("with multiple queries", () => {
+      it("works with default path+input from provider, per-query fromResult", async () => {
+        let hash1: string;
+        let hash2: string;
+        const evaluateSpy = vi
+          .spyOn(opa, "evaluateBatch")
+          .mockImplementationOnce((_path, inputs, _opts) => {
+            Object.entries(inputs).forEach(([k, inp]) => {
+              if ((inp as any).a === "foo") {
+                hash1 = k;
+              } else {
+                hash2 = k;
+              }
+            });
+            return Promise.resolve({
+              [hash1]: { foo: false },
+              [hash2]: { bar: true },
+            });
+          });
+
+        const in1 = { a: "foo" };
+        const in2 = { b: "bar" };
+        const { result } = renderHook(
+          () =>
+            useAuthz([
+              { input: in1, fromResult: (x?: Result) => (x as any).foo },
+              { input: in2, fromResult: (x?: Result) => (x as any).bar },
+            ]),
+          wrapper({
+            defaultPath: "def/ault",
+            defaultInput: { user: "alice" },
+            batch: true,
+          }),
+        );
+        await waitFor(() =>
+          expect(result.current).toMatchObject([
+            {
+              isLoading: false,
+              error: undefined,
+              result: false,
+            },
+            {
+              isLoading: false,
+              error: undefined,
+              result: true,
+            },
+          ]),
+        );
+        expect(evaluateSpy).toHaveBeenCalledTimes(1);
+        expect(evaluateSpy).toHaveBeenCalledWith(
+          "def/ault",
+          {
+            [hash1]: { user: "alice", ...in1 },
+            [hash2]: { user: "alice", ...in2 },
+          },
+          expect.anything(),
+        );
+      });
+      it("rejects evals without path", async () => {
+        const evaluateSpy = vi.spyOn(opa, "evaluateBatch");
+
+        const { result } = renderHook(
+          () => useAuthz([{ input: "some input" }]),
+          wrapper({ batch }),
+        );
+        await waitFor(() =>
+          expect(result.current).toMatchObject([
+            {
+              isLoading: false,
+              error: new Error(
+                "batch requests need to have a defined query path",
+              ),
+              result: undefined,
+            },
+          ]),
+        );
+        expect(evaluateSpy).not.toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
Trying to create a pixel-grid demo, it became apparent that the same use case that makes `react-query` *need* `useQueries` exists for opa-react:

If you don't know the number of evaluations you need, or if you want to do evaluations in a loop, you cannot do that with the "single-decision" `useAuthz` call.

So now, you can provide an array of evaluation queries,
```ts
{
    path?: string;
    input?: Input;
    fromResult?: (_?: Result) => boolean;
  }[],
```
instead, and you'll get a `UseAuthzResult<T>[]` in return.