### PR TITLE
ucast-prisma: project conditions for primary table

### DIFF
--- a/packages/ucast-prisma/src/adapter.ts
+++ b/packages/ucast-prisma/src/adapter.ts
@@ -3,7 +3,10 @@ import { createPrismaInterpreter } from "./interpreter.js";
 import * as instructions from "./instructions.js";
 import * as interpreters from "./interpreters.js";
 
-export function ucastToPrisma(ucast: Record<string, any>): Record<string, any> {
+export function ucastToPrisma(
+  ucast: Record<string, any>,
+  primary: string
+): Record<string, any> {
   const parsed = new ObjectQueryParser(instructions).parse(ucast);
-  return createPrismaInterpreter(interpreters)(parsed);
+  return createPrismaInterpreter(primary, interpreters)(parsed);
 }

--- a/packages/ucast-prisma/src/interpreter.ts
+++ b/packages/ucast-prisma/src/interpreter.ts
@@ -6,15 +6,32 @@ import {
 import merge from "lodash.merge";
 
 export class Query {
+  private _primary: string;
   private _tableConditions: Record<string, Object> = {};
 
+  constructor(primary: string) {
+    this._primary = primary;
+  }
+
+  isPrimary(tbl: string): boolean {
+    return tbl === this._primary;
+  }
+
+  addPrimaryCondition(cond: Object) {
+    this.addCondition(this._primary, cond);
+  }
+
   addCondition(table: string, cond: Object) {
-    this._tableConditions[table] = merge(this._tableConditions[table], cond);
+    if (table !== this._primary) {
+      this._tableConditions[table] = merge(this._tableConditions[table], cond);
+    } else {
+      this._tableConditions = merge(this._tableConditions, cond);
+    }
     return this;
   }
 
   child(): Query {
-    return new Query();
+    return new Query(this._primary);
   }
 
   merge(other: Query): Query {
@@ -37,8 +54,10 @@ export type PrismaOperator<C extends Condition> = (
 ) => Query;
 
 export function createPrismaInterpreter(
+  primary: string,
   operators: Record<string, PrismaOperator<any>> // TODO(sr): this <any> doesn't feel right.
 ) {
   const interpret = createInterpreter<PrismaOperator<any>>(operators);
-  return (condition: Condition) => interpret(condition, new Query()).toJSON();
+  return (condition: Condition) =>
+    interpret(condition, new Query(primary)).toJSON();
 }

--- a/packages/ucast-prisma/tests/interpreters.test.ts
+++ b/packages/ucast-prisma/tests/interpreters.test.ts
@@ -5,18 +5,18 @@ import { describe, it, expect } from "vitest";
 
 describe("Condition interpreter", () => {
   describe("field operators", () => {
-    const interpret = createPrismaInterpreter(interpreters);
+    const interpret = createPrismaInterpreter("table", interpreters);
 
     it('generates query with `equals operator for "eq"', () => {
       const condition = new FieldCondition("eq", "table.name", "test");
       const f = interpret(condition);
-      expect(f).toStrictEqual({ table: { name: { equals: "test" } } });
+      expect(f).toStrictEqual({ name: { equals: "test" } });
     });
 
     it('generates query with `not` operator for "ne"', () => {
       const condition = new FieldCondition("ne", "table.name", "test");
       const f = interpret(condition);
-      expect(f).toStrictEqual({ table: { name: { not: "test" } } });
+      expect(f).toStrictEqual({ name: { not: "test" } });
     });
 
     it('generates query with `in` operator for "in" with array value', () => {
@@ -25,7 +25,7 @@ describe("Condition interpreter", () => {
         "another",
       ]);
       const f = interpret(condition);
-      expect(f).toStrictEqual({ table: { name: { in: ["test", "another"] } } });
+      expect(f).toStrictEqual({ name: { in: ["test", "another"] } });
     });
 
     it('generates query with `notIn` operator for "notIn" with array value', () => {
@@ -34,14 +34,12 @@ describe("Condition interpreter", () => {
         "another",
       ]);
       const f = interpret(condition);
-      expect(f).toStrictEqual({
-        table: { name: { notIn: ["test", "another"] } },
-      });
+      expect(f).toStrictEqual({ name: { notIn: ["test", "another"] } });
     });
   });
 
   describe("compound operators", () => {
-    const interpret = createPrismaInterpreter(interpreters);
+    const interpret = createPrismaInterpreter("user", interpreters);
 
     it('generates query without extra fluff for "AND"', () => {
       const condition = new CompoundCondition("and", [
@@ -51,11 +49,9 @@ describe("Condition interpreter", () => {
       const f = interpret(condition);
 
       expect(f).toStrictEqual({
-        user: {
-          age: {
-            lt: 12,
-            gt: 40,
-          },
+        age: {
+          lt: 12,
+          gt: 40,
         },
       });
     });
@@ -68,20 +64,18 @@ describe("Condition interpreter", () => {
       const f = interpret(condition);
 
       expect(f).toStrictEqual({
-        user: {
-          OR: [
-            {
-              age: {
-                lt: 12,
-              },
+        OR: [
+          {
+            age: {
+              lt: 12,
             },
-            {
-              age: {
-                gt: 40,
-              },
+          },
+          {
+            age: {
+              gt: 40,
             },
-          ],
-        },
+          },
+        ],
       });
     });
 
@@ -95,25 +89,25 @@ describe("Condition interpreter", () => {
       const f = interpret(condition);
 
       expect(f).toStrictEqual({
-        user: {
-          OR: [
-            {
-              id: {
-                equals: 12,
-              },
+        OR: [
+          {
+            id: {
+              equals: 12,
             },
-            {
-              age: {
-                gt: 20,
-              },
-            },
-          ],
-        },
-        customer: {
-          id: {
-            equals: 40,
           },
-        },
+          {
+            age: {
+              gt: 20,
+            },
+          },
+          {
+            customer: {
+              id: {
+                equals: 40,
+              },
+            },
+          },
+        ],
       });
     });
   });


### PR DESCRIPTION
The way OR was destructured before caused problems 😅 

Now, the ucastToPrisma adapter takes a string of the primary database that this query is for, to make the necessary adjustments for being able to put the returned query filter into the prisma call as-is.