### PR TITLE
ucast-prisma: support translation table and col names

### DIFF
--- a/.changeset/hip-files-repair.md
+++ b/.changeset/hip-files-repair.md
@@ -1,0 +1,27 @@
+---
+"@styra/ucast-prisma": patch
+---
+
+support translating table and column names via extra options
+
+An extra options object can be passed to `ucastToPrisma` to translate table and column names.
+This is useful when the Prisma schema uses different names than the OPA policy used to generate
+the conditions.
+
+```typescript
+const p = ucastToPrisma(
+  { or: [{ "tickets.resolved": false }, { "users.name": "ceasar" }] },
+  "tickets0",
+  {
+    translations: {
+      tickets: { $self: "tickets0", resolved: "resolved0" },
+      users: { $self: "users0", name: "name0" },
+    },
+  }
+);
+```
+
+In this example, the conditions `{ or: [{ "tickets.resolved": false }, { "users.name": "ceasar" }] }`
+will be rewritten to `{ OR: [{ tickets0: { resolved0: false } }, { users0: { name0: "ceasar" } }] }`,
+assuming that the Prisma schema uses `tickets0` and `users0` as table names and `resolved0` and `name0`
+as column names respectively.

--- a/packages/ucast-prisma/src/adapter.ts
+++ b/packages/ucast-prisma/src/adapter.ts
@@ -3,10 +3,22 @@ import { createPrismaInterpreter } from "./interpreter.js";
 import * as instructions from "./instructions.js";
 import * as interpreters from "./interpreters.js";
 
+export type Options = {
+  translations?: Record<string, Record<string, string>>;
+};
+
 export function ucastToPrisma(
   ucast: Record<string, any>,
-  primary: string
+  primary: string,
+  { translations }: Options = {}
 ): Record<string, any> {
   const parsed = new ObjectQueryParser(instructions).parse(ucast);
-  return createPrismaInterpreter(primary, interpreters)(parsed);
+  return createPrismaInterpreter(primary, {
+    interpreters,
+    translate: (tbl: string, col: string): [string, string] => {
+      const tbl0 = translations?.[tbl]?.$self || tbl;
+      const col0 = translations?.[tbl]?.[col] || col;
+      return [tbl0, col0];
+    },
+  })(parsed);
 }

--- a/packages/ucast-prisma/src/interpreter.ts
+++ b/packages/ucast-prisma/src/interpreter.ts
@@ -61,11 +61,24 @@ export type PrismaOperator<C extends Condition> = (
   context: InterpretationContext<PrismaOperator<C>>
 ) => Query;
 
+export type interpreterOpts = {
+  interpreters: Record<string, PrismaOperator<any>>; // TODO(sr): this <any> doesn't feel right.
+} & translateOpts;
+
+export type translateOpts = {
+  translate?: (tbl: string, col: string) => [string, string];
+};
+
 export function createPrismaInterpreter(
   primary: string,
-  operators: Record<string, PrismaOperator<any>> // TODO(sr): this <any> doesn't feel right.
+  { interpreters, translate }: interpreterOpts
 ) {
-  const interpret = createInterpreter<PrismaOperator<any>>(operators);
+  const interpret = createInterpreter<PrismaOperator<any>, translateOpts>(
+    interpreters,
+    {
+      translate,
+    }
+  );
   return (condition: Condition) =>
     interpret(condition, new Query(primary)).toJSON();
 }

--- a/packages/ucast-prisma/src/interpreters.ts
+++ b/packages/ucast-prisma/src/interpreters.ts
@@ -3,8 +3,9 @@ import {
   FieldCondition,
   Condition,
   Comparable,
+  InterpretationContext,
 } from "@ucast/core";
-import { PrismaOperator } from "./interpreter.js";
+import { translateOpts, PrismaOperator } from "./interpreter.js";
 
 export const eq = op("equals");
 export const ne = op("not");
@@ -53,8 +54,11 @@ export const or: PrismaOperator<CompoundCondition> = (
 };
 
 function op<T>(name: string): PrismaOperator<FieldCondition<T>> {
-  return (condition, query) => {
-    const [tbl, field] = condition.field.split(".");
+  return (condition, query, options) => {
+    const translate =
+      (options as translateOpts)?.translate || // NOTE(sr): The 'as' here feels wrong, but I couldn't make it work otherwise.
+      ((...x: string[]) => [x[0], x[1]]);
+    const [tbl, field] = translate(...condition.field.split("."));
     return query.addCondition(tbl, { [field]: { [name]: condition.value } });
   };
 }

--- a/packages/ucast-prisma/tests/adapter.test.ts
+++ b/packages/ucast-prisma/tests/adapter.test.ts
@@ -61,4 +61,59 @@ describe("ucastToPrisma", () => {
       });
     });
   });
+  describe("translations", () => {
+    describe("field operators", () => {
+      it("converts column names", () => {
+        const p = ucastToPrisma({ "table.name": "test" }, "table", {
+          translations: { table: { name: "name_col" } },
+        });
+        expect(p).toStrictEqual({ name_col: { equals: "test" } });
+      });
+
+      it("converts table names", () => {
+        const p = ucastToPrisma({ "table.name": "test" }, "tbl", {
+          translations: { table: { $self: "tbl" } },
+        });
+        expect(p).toStrictEqual({ name: { equals: "test" } });
+      });
+
+      it("converts multiple table+col names", () => {
+        const p = ucastToPrisma(
+          { "table.name": "test", "user.name": "alice" },
+          "tbl",
+          {
+            translations: {
+              table: { $self: "tbl", name: "name_col" },
+              user: { $self: "usr", name: "name_col_0" },
+            },
+          }
+        );
+        expect(p).toStrictEqual({
+          name_col: { equals: "test" },
+          usr: { name_col_0: { equals: "alice" } },
+        });
+      });
+    });
+
+    describe("compound operators", () => {
+      it("supports translations for 'or'", () => {
+        const p = ucastToPrisma(
+          { or: [{ "tickets.resolved": false }, { "users.name": "ceasar" }] },
+          "tickets0",
+          {
+            translations: {
+              tickets: { $self: "tickets0", resolved: "resolved0" },
+              users: { $self: "users0", name: "name0" },
+            },
+          }
+        );
+        expect(p).toStrictEqual({
+          OR: [
+            { resolved0: { equals: false } },
+            { users0: { name0: { equals: "ceasar" } } },
+          ],
+        });
+      });
+    });
+  });
 });

--- a/packages/ucast-prisma/tests/interpreters.test.ts
+++ b/packages/ucast-prisma/tests/interpreters.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect } from "vitest";
 
 describe("Condition interpreter", () => {
   describe("field operators", () => {
-    const interpret = createPrismaInterpreter("table", interpreters);
+    const interpret = createPrismaInterpreter("table", { interpreters });
 
     it('generates query with `equals operator for "eq"', () => {
       const condition = new FieldCondition("eq", "table.name", "test");
@@ -39,7 +39,7 @@ describe("Condition interpreter", () => {
   });
 
   describe("compound operators", () => {
-    const interpret = createPrismaInterpreter("user", interpreters);
+    const interpret = createPrismaInterpreter("user", { interpreters });
 
     it('generates query without extra fluff for "AND"', () => {
       const condition = new CompoundCondition("and", [


### PR DESCRIPTION
## support translating table and column names via extra options

An extra options object can be passed to `ucastToPrisma` to translate table and column names.
This is useful when the Prisma schema uses different names than the OPA policy used to generate
the conditions.

```typescript
const p = ucastToPrisma(
  { or: [{ "tickets.resolved": false }, { "users.name": "ceasar" }] },
  "tickets0",
  {
    translations: {
      tickets: { $self: "tickets0", resolved: "resolved0" },
      users: { $self: "users0", name: "name0" },
    },
  }
);
```

In this example, the conditions `{ or: [{ "tickets.resolved": false }, { "users.name": "ceasar" }] }`
will be rewritten to `{ OR: [{ tickets0: { resolved0: false } }, { users0: { name0: "ceasar" } }] }`,
assuming that the Prisma schema uses `tickets0` and `users0` as table names and `resolved0` and `name0`
as column names respectively.