### PR TITLE
ucast-prisma: support expanded input

### DIFF
--- a/.changeset/poor-walls-judge.md
+++ b/.changeset/poor-walls-judge.md
@@ -1,0 +1,5 @@
+---
+"@styra/ucast-prisma": patch
+---
+
+support previously-expanded conditions output

--- a/packages/ucast-prisma/src/adapter.ts
+++ b/packages/ucast-prisma/src/adapter.ts
@@ -1,4 +1,4 @@
-import { ObjectQueryParser } from "@ucast/core";
+import { ObjectQueryParser, type Condition } from "@ucast/core";
 import { createPrismaInterpreter } from "./interpreter.js";
 import * as instructions from "./instructions.js";
 import * as interpreters from "./interpreters.js";
@@ -12,7 +12,10 @@ export function ucastToPrisma(
   primary: string,
   { translations }: Options = {}
 ): Record<string, any> {
-  const parsed = new ObjectQueryParser(instructions).parse(ucast);
+  const parsed =
+    "type" in ucast && "value" in ucast && "operator" in ucast
+      ? (ucast as Condition<unknown>)
+      : new ObjectQueryParser(instructions).parse(ucast);
   return createPrismaInterpreter(primary, {
     interpreters,
     translate: (tbl: string, col: string): [string, string] => {

--- a/packages/ucast-prisma/tests/adapter.test.ts
+++ b/packages/ucast-prisma/tests/adapter.test.ts
@@ -8,6 +8,14 @@ describe("ucastToPrisma", () => {
       expect(p).toStrictEqual({ name: { equals: "test" } });
     });
 
+    it("deals with expanded input", () => {
+      const p = ucastToPrisma(
+        { type: "field", operator: "eq", value: "test", field: "table.name" },
+        "table"
+      );
+      expect(p).toStrictEqual({ name: { equals: "test" } });
+    });
+
     it("converts 'eq' to 'equals'", () => {
       const p = ucastToPrisma({ "table.name": { eq: "test" } }, "table");
       expect(p).toStrictEqual({ name: { equals: "test" } });
@@ -60,7 +68,50 @@ describe("ucastToPrisma", () => {
         ],
       });
     });
+
+    it("handles 'or' with multiple conditions in one disjunct (expanded format)", () => {
+      const p = ucastToPrisma(
+        {
+          type: "compound",
+          operator: "or",
+          value: [
+            {
+              type: "compound",
+              operator: "and",
+              value: [
+                {
+                  type: "field",
+                  operator: "eq",
+                  field: "tickets.resolved",
+                  value: false,
+                },
+                {
+                  type: "field",
+                  operator: "eq",
+                  field: "tickets.assignee",
+                  value: null,
+                },
+              ],
+            },
+            {
+              type: "field",
+              operator: "eq",
+              field: "users.name",
+              value: "ceasar",
+            },
+          ],
+        },
+        "tickets"
+      );
+      expect(p).toStrictEqual({
+        OR: [
+          { resolved: { equals: false }, assignee: { equals: null } },
+          { users: { name: { equals: "ceasar" } } },
+        ],
+      });
+    });
   });
+
   describe("translations", () => {
     describe("field operators", () => {
       it("converts column names", () => {


### PR DESCRIPTION
`ucastToPrisma` should now also support previously-expanded conditions input.