### PR TITLE
ucast-prisma: switch to non-concise AND encoding of conjuncts

### DIFF
--- a/.changeset/dry-kiwis-marry.md
+++ b/.changeset/dry-kiwis-marry.md
@@ -1,0 +1,9 @@
+---
+"@styra/ucast-prisma": patch
+---
+
+ucast-prisma: switch to non-concise AND encoding of conjuncts
+
+This isn't as concise as before, but it's free of edge cases.
+Also, as far as I can tell from the [Prisma docs](https://www.prisma.io/docs/orm/reference/prisma-client-reference#and), it doesn't
+matter if multiple conditions are wrapped in AND or not.

--- a/packages/ucast-prisma/tests/adapter.test.ts
+++ b/packages/ucast-prisma/tests/adapter.test.ts
@@ -63,7 +63,12 @@ describe("ucastToPrisma", () => {
       );
       expect(p).toStrictEqual({
         OR: [
-          { resolved: { equals: false }, private: { equals: true } },
+          {
+            AND: [
+              { resolved: { equals: false } },
+              { private: { equals: true } },
+            ],
+          },
           { users: { name: { equals: "ceasar" } } },
         ],
       });
@@ -105,7 +110,12 @@ describe("ucastToPrisma", () => {
       );
       expect(p).toStrictEqual({
         OR: [
-          { resolved: { equals: false }, assignee: { equals: null } },
+          {
+            AND: [
+              { resolved: { equals: false } },
+              { assignee: { equals: null } },
+            ],
+          },
           { users: { name: { equals: "ceasar" } } },
         ],
       });
@@ -140,8 +150,10 @@ describe("ucastToPrisma", () => {
           }
         );
         expect(p).toStrictEqual({
-          name_col: { equals: "test" },
-          usr: { name_col_0: { equals: "alice" } },
+          AND: [
+            { name_col: { equals: "test" } },
+            { usr: { name_col_0: { equals: "alice" } } },
+          ],
         });
       });
     });


### PR DESCRIPTION
This isn't as concise as before, but it's free of edge cases. Also, as far as I can tell from the Prisma docs[1], it doesn't matter if multiple conditions are wrapped in AND or not.

[1]: https://www.prisma.io/docs/orm/reference/prisma-client-reference#and