### PR TITLE
ucast-prisma: add support for NOT

### DIFF
--- a/packages/ucast-prisma/src/interpreter.ts
+++ b/packages/ucast-prisma/src/interpreter.ts
@@ -1,7 +1,7 @@
 import {
   createInterpreter,
-  Condition,
-  InterpretationContext,
+  type Condition,
+  type InterpretationContext,
 } from "@ucast/core";
 import merge from "lodash.merge";
 

--- a/packages/ucast-prisma/src/interpreters.ts
+++ b/packages/ucast-prisma/src/interpreters.ts
@@ -3,7 +3,11 @@ import type {
   FieldCondition,
   Comparable,
 } from "@ucast/core";
-import type { translateOpts, PrismaOperator } from "./interpreter.js";
+import {
+  type translateOpts,
+  type PrismaOperator,
+  Query,
+} from "./interpreter.js";
 
 export const eq = op("equals");
 export const ne = op("not");
@@ -54,6 +58,23 @@ export const or: PrismaOperator<CompoundCondition> = (
     query.addPrimaryCondition(or[0]);
   }
 
+  return query;
+};
+
+export const not: PrismaOperator<CompoundCondition> = (
+  condition,
+  query,
+  { interpret }
+) => {
+  if (condition.value.length > 1) {
+    throw new Error("NOT condition must have exactly one child");
+  }
+
+  const [tbl] = (condition.value[0] as FieldCondition).field.split(".");
+  const not = new Query(tbl);
+  interpret(condition.value[0], not);
+
+  query.addCondition(tbl, { NOT: not.toJSON() });
   return query;
 };
 

--- a/packages/ucast-prisma/tests/interpreters.test.ts
+++ b/packages/ucast-prisma/tests/interpreters.test.ts
@@ -81,7 +81,7 @@ describe("Condition interpreter", () => {
       });
     });
 
-    it('generates query with with OR for "or"', () => {
+    it('generates query with OR for "or"', () => {
       const condition = new CompoundCondition("or", [
         new FieldCondition("lt", "user.age", 12),
         new FieldCondition("gt", "user.age", 40),
@@ -139,6 +139,33 @@ describe("Condition interpreter", () => {
             },
           },
         ],
+      });
+    });
+
+    it('generates query with NOT for "not", projected to primary table (user)', () => {
+      const condition = new CompoundCondition("not", [
+        new FieldCondition("lt", "user.age", 18),
+      ]);
+      const f = interpret(condition);
+
+      expect(f).toStrictEqual({
+        NOT: {
+          age: {
+            lt: 18,
+          },
+        },
+      });
+    });
+
+    it('generates query with NOT for "not", threaded in for secondary table (customer)', () => {
+      const condition = new CompoundCondition("not", [
+        new FieldCondition("eq", "customer.id", 40),
+      ]);
+      const f = interpret(condition);
+      expect(f).toStrictEqual({
+        customer: {
+          NOT: { id: { equals: 40 } },
+        },
       });
     });
 


### PR DESCRIPTION
With the proper threading-in of the NOT operator, depending on whether it's about the primary or a related table.