### PR TITLE
ucast-prisma: add mask utilities

### DIFF
--- a/.changeset/neat-clubs-exist.md
+++ b/.changeset/neat-clubs-exist.md
@@ -1,0 +1,10 @@
+---
+"@styra/ucast-prisma": minor
+---
+
+add helper methods for column masking in filter results
+
+A new `mask` method for masking column values in database lookup results,
+according to mask rules provided by the Compile API, has been added.
+
+Also, an `Adapter` class was added to make calls for filtering and masking with Prisma more streamlined.

--- a/packages/opa/src/opaclient.ts
+++ b/packages/opa/src/opaclient.ts
@@ -121,7 +121,7 @@ export interface FiltersOptions extends FetchOptions {
 }
 
 export type Filters = {
-  query?: string | {} | undefined;
+  query?: string | Record<string, any> | undefined;
   masks?: { [k: string]: any } | undefined;
 };
 

--- a/packages/ucast-prisma/src/adapter.ts
+++ b/packages/ucast-prisma/src/adapter.ts
@@ -1,7 +1,14 @@
+import {
+  OPAClient,
+  type Input,
+  ToInput,
+  FiltersRequestOptions,
+} from "@styra/opa";
 import { ObjectQueryParser, type Condition } from "@ucast/core";
-import { createPrismaInterpreter } from "./interpreter.js";
 import * as instructions from "./instructions.js";
+import { createPrismaInterpreter } from "./interpreter.js";
 import * as interpreters from "./interpreters.js";
+import { mask } from "./masks.js";
 
 export type Options = {
   translations?: Record<string, Record<string, string>>;
@@ -24,4 +31,32 @@ export function ucastToPrisma(
       return [tbl0, col0];
     },
   })(parsed);
+}
+
+export interface Filters {
+  query: Record<string, any>;
+  mask<T extends Record<string, any>>(item: T): T;
+}
+
+export class Adapter extends OPAClient {
+  async filters<In extends Input | ToInput>(
+    path: string,
+    primary: string,
+    input?: In,
+    opts?: Exclude<FiltersRequestOptions, "target">
+  ): Promise<Filters> {
+    const { query, masks } = await super.getFilters(path, input, {
+      ...opts,
+      target: "ucastPrisma",
+    });
+
+    return {
+      query: ucastToPrisma(query as Record<string, any>, primary),
+      mask<T extends Record<string, any>>(item: T): T {
+        if (!masks) return item; // pass-through
+
+        return mask(masks, item, primary);
+      },
+    };
+  }
 }

--- a/packages/ucast-prisma/src/index.ts
+++ b/packages/ucast-prisma/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./adapter.js";
+export * from "./masks.js";

--- a/packages/ucast-prisma/src/masks.ts
+++ b/packages/ucast-prisma/src/masks.ts
@@ -1,0 +1,144 @@
+/**
+ * MaskRule defines the currently supported types of mask rules for usage with
+ * {@link mask}.
+ */
+export interface MaskRule {
+  replace: { value: any };
+}
+
+/**
+ * Apply masking rules to an object (i.e. "mask" it)
+ *
+ * @param maskRules Masking rules as returned from the Compile API.
+ * @param targetObject Object to apply replacements to
+ * @param targetType Type of the object to apply replacements to (prefix of maskRules).
+ * @returns A new object with values replaced according to the rules
+ */
+export function mask<T extends Record<string, any>>(
+  maskRules: Record<string, Record<string, MaskRule> | MaskRule>,
+  targetObject: T,
+  targetType?: string
+): T {
+  if (targetType) {
+    // optionally project mask rules to target type
+    maskRules = project(maskRules as Record<string, MaskRule>, targetType);
+  }
+
+  // Create a deep clone of the target object to avoid mutating the original
+  const result = JSON.parse(JSON.stringify(targetObject)) as Record<
+    string,
+    any
+  >;
+
+  // Process top-level replacements
+  for (const key in maskRules) {
+    let rule = maskRules[key];
+
+    // If it's for the primary target, i.e. non-nested.
+    if (
+      rule &&
+      typeof rule === "object" &&
+      "replace" in rule &&
+      typeof rule.replace === "object" &&
+      "value" in rule.replace
+    ) {
+      // Apply to the target if the key exists
+      if (key in result) {
+        result[key] = rule.replace.value;
+      }
+    }
+    // If it's a nested object with rules for child properties
+    else if (rule && typeof rule === "object" && !rule.replace) {
+      rule = rule as Record<string, MaskRule>;
+      // Apply rules to child properties (one level deep only)
+      if (key in result && result[key] && typeof result[key] === "object") {
+        for (const childKey in rule) {
+          const childRule = rule[childKey];
+
+          // Check if the child rule is a valid replacement rule
+          if (
+            childRule &&
+            typeof childRule === "object" &&
+            "replace" in childRule &&
+            typeof childRule.replace === "object" &&
+            "value" in childRule.replace
+          ) {
+            // Apply to the child property if it exists
+            if (childKey in result[key]) {
+              result[key][childKey] = childRule.replace.value;
+            }
+          }
+        }
+      }
+    }
+  }
+  return result as T;
+}
+
+/**
+ * Filter an object by key prefix, removing the prefix from the keys.
+ *
+ * @param obj The object to filter, e.g. `{"users.id": {...}, "groups.name": {...}}`
+ * @param type The prefix to filter by (e.g. "users")
+ * @returns A new object with only keys that had the specified prefix, with the prefix removed
+ */
+export function project(
+  obj: Record<string, MaskRule>,
+  type: string
+): Record<string, MaskRule> {
+  const { [type]: primary, ...rest } = splitKeys(obj);
+  return { ...primary, ...rest };
+}
+
+/**
+ * Transforms an object (maskRules) with dot-notation keys into a nested structure
+ *
+ * @example
+ * Input: { "users.age": {"replace": {"value": "hidden"}} }
+ * Output: { "users": { "age": {"replace": {"value": "hidden"}} } }
+ *
+ * @param maskRules Mask rules object with dot-notation keys, e.g. `{ "users.age": {"replace": {"value": "hidden"}} }`
+ * @returns Nested object structure, e.g. `{ "users": { "age": {"replace": {"value": "hidden"}} } }`
+ */
+function splitKeys(maskRules: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {};
+
+  // Process each key in the flat object
+  for (const [key, value] of Object.entries(maskRules)) {
+    // Split the key by dot notation
+    const pathParts = key.split(".");
+
+    // Start from the root of our result object
+    let current = result;
+
+    // Navigate through each path part except the last one
+    for (let i = 0; i < pathParts.length - 1; i++) {
+      const part = pathParts[i] as string; // can't be undefined
+
+      // If this path doesn't exist yet, create it
+      if (!current[part]) {
+        current[part] = {};
+      }
+      // If it exists but isn't an object, we have a conflict
+      else if (
+        typeof current[part] !== "object" ||
+        Array.isArray(current[part])
+      ) {
+        throw new Error(
+          `Path conflict at ${pathParts
+            .slice(0, i + 1)
+            .join(".")}: Expected an object but found ${typeof current[part]}`
+        );
+      }
+
+      // Move to the next level of nesting
+      current = current[part];
+    }
+
+    // Set the value at the final path part
+    const lastPart = pathParts[pathParts.length - 1] as string;
+    current[lastPart] = value;
+  }
+
+  return result;
+}

--- a/packages/ucast-prisma/tests/masks.test.ts
+++ b/packages/ucast-prisma/tests/masks.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { project, mask } from "../src";
+
+describe("masking", () => {
+  it("works for complete example", () => {
+    const tickets = [
+      { id: 0, descr: "something wrong", reporter: "John Doe", assignee: null },
+      {
+        id: 1,
+        descr: "something else wrong",
+        reporter: "Jane Doe",
+        assignee: 12,
+      },
+      {
+        id: 2,
+        descr: "everything wrong",
+        reporter: "Joanna Doe",
+        assignee: 100,
+      },
+    ];
+    const masks = {
+      "tickets.reporter": { replace: { value: "<redacted>" } },
+      "tickets.assignee": { replace: { value: null } },
+      "users.id": { replace: { value: "___" } },
+    };
+    const act = tickets.map((ticket) => mask(masks, ticket, "tickets"));
+    expect(act).toStrictEqual([
+      {
+        id: 0,
+        descr: "something wrong",
+        reporter: "<redacted>",
+        assignee: null,
+      },
+      {
+        id: 1,
+        descr: "something else wrong",
+        reporter: "<redacted>",
+        assignee: null,
+      },
+      {
+        id: 2,
+        descr: "everything wrong",
+        reporter: "<redacted>",
+        assignee: null,
+      },
+    ]);
+  });
+
+  describe("mask", () => {
+    it("replaces according to mask rules", () => {
+      const act = mask(
+        {
+          id: { replace: { value: "***" } },
+          phone: { replace: { value: "---" } },
+        },
+        { id: "agathe", tea: "green", phone: "00347232132341" }
+      );
+      expect(act).toStrictEqual({ id: "***", tea: "green", phone: "---" });
+    });
+
+    it("copes with missing values", () => {
+      const act = mask(
+        {
+          id: { replace: { value: "***" } },
+          phone: {},
+        },
+        { id: "agathe", tea: "green", phone: "00347232132341" }
+      );
+      expect(act).toStrictEqual({
+        id: "***",
+        tea: "green",
+        phone: "00347232132341",
+      });
+    });
+
+    it("replaces according to mask rules, with projection and related fields", () => {
+      const act = mask(
+        {
+          "users.id": { replace: { value: "***" } },
+          "users.phone": { replace: { value: "---" } },
+          "address.street": { replace: { value: "sesame" } },
+        },
+        {
+          id: "agathe",
+          tea: "green",
+          phone: "00347232132341",
+          address: { street: "main" },
+        },
+        "users"
+      );
+      expect(act).toStrictEqual({
+        id: "***",
+        tea: "green",
+        phone: "---",
+        address: { street: "sesame" },
+      });
+    });
+
+    it("replaces according to mask rules, also non-strings", () => {
+      const act = mask(
+        { id: { replace: { value: true } } },
+        { id: "agathe", tea: "green" }
+      );
+      expect(act).toStrictEqual({ id: true, tea: "green" });
+    });
+
+    it("ignores unknown mask rules", () => {
+      const act = mask(
+        {
+          id: { prefix: { value: "***" } },
+          phone: { suffix: { value: "---" } },
+        } as any, // NOTE(sr): "as any" deliberate to check against unknown mask input
+        { id: "agathe", tea: "green", phone: "00347232132341" }
+      );
+      expect(act).toStrictEqual({
+        id: "agathe",
+        tea: "green",
+        phone: "00347232132341",
+      });
+    });
+  });
+
+  describe("project", () => {
+    it("drops the prefixes (1)", () => {
+      const act = project(
+        { "users.id": { replace: { value: "***" } } },
+        "users"
+      );
+      expect(act).toStrictEqual({ id: { replace: { value: "***" } } });
+    });
+
+    it("drops the prefixes (n)", () => {
+      const act = project(
+        {
+          "users.id": { replace: { value: "***" } },
+          "users.name": { replace: { value: "<name>" } },
+        },
+        "users"
+      );
+      expect(act).toStrictEqual({
+        id: { replace: { value: "***" } },
+        name: { replace: { value: "<name>" } },
+      });
+    });
+
+    it("keeps prefixes on mask rules for related (non-primary) objects", () => {
+      const act = project(
+        {
+          "users.id": { replace: { value: "***" } },
+          "tenants.id": { replace: { value: "---" } },
+        },
+        "users"
+      );
+      expect(act).toStrictEqual({
+        id: { replace: { value: "***" } },
+        tenants: { id: { replace: { value: "---" } } },
+      });
+    });
+
+    it("can have no primary masks if there are none matching", () => {
+      const act = project(
+        {
+          "tenants.id": { replace: { value: "---" } },
+        },
+        "users"
+      );
+      expect(act).toStrictEqual({
+        tenants: { id: { replace: { value: "---" } } },
+      });
+    });
+  });
+});


### PR DESCRIPTION
A new `mask` method for masking column values in database lookup results,
according to mask rules provided by the Compile API, has been added.