### PR TITLE
ci: fix changesets/action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: StyraInc/changesets-action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # v1.4.7
+        uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # v1.4.7
         with:
           publish: npm run publish
         env:


### PR DESCRIPTION
We had been mirroring this because it had problems with GitHub quotas, let's see how it works these days without that.