### PR TITLE
patch-release all packages

### DIFF
--- a/.changeset/good-olives-dress.md
+++ b/.changeset/good-olives-dress.md
@@ -1,0 +1,10 @@
+---
+"@open-policy-agent/opa": patch
+"@open-policy-agent/opa-react": patch
+"@open-policy-agent/ucast-prisma": patch
+---
+
+TS SDK: first release under @open-policy-agent NPM org
+
+Besides renames and dependency bumps, there is no functional change in this patch release
+over the packages previously published in the @styra NPM org.


### PR DESCRIPTION
Preparing the release of all packages under the open-policy-agent org. This PR alone will only trigger the changesets PR, not a release. For the release, we first need to adjust the NPM_TOKEN in this repo.