### PR TITLE
opa: update Compile API headers for OPA v1.9.0

### DIFF
--- a/.changeset/large-coats-listen.md
+++ b/.changeset/large-coats-listen.md
@@ -1,0 +1,8 @@
+---
+"@open-policy-agent/opa": major
+---
+
+Support for Compile API filter generation in OPA v1.9.0 (EOPA v1.44.0).
+
+- [OPA v1.9.0](https://github.com/open-policy-agent/opa/releases/tag/v1.9.0)
+- [EOPA v1.44.0](https://github.com/open-policy-agent/eopa/releases/tag/v1.44.0)

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 Styra, Inc.
+   Copyright 2025 The OPA Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/build/opa-release-notes.sh
+++ b/build/opa-release-notes.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# This takes the last block (by record separator "\n## ") and removes the first line (timestamp)
-awk 'BEGIN { RS="\n## "} END { print $0 }' packages/opa/RELEASES.md | \
-  tail +2
-
-envsubst '$VERSION' <<EOF
-- [NPM ${VERSION}](https://www.npmjs.com/package/@styra/opa/v/${VERSION})
-EOF

--- a/packages/opa-react/README.md
+++ b/packages/opa-react/README.md
@@ -1,7 +1,7 @@
 # @open-policy-agent/opa-react
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![NPM Version](https://img.shields.io/npm/v/%40styra%2Fopa-react?style=flat&color=%2324b6e0)](https://www.npmjs.com/package/@open-policy-agent/opa-react)
+[![NPM Version](https://img.shields.io/npm/v/%40open-policy-agent%2Fopa-react?style=flat&color=%2324b6e0)](https://www.npmjs.com/package/@open-policy-agent/opa-react)
 
 This package contains helpers for using [@open-policy-agent/opa](https://www.npmjs.com/package/@open-policy-agent/opa) from React.
 

--- a/packages/opa/README.md
+++ b/packages/opa/README.md
@@ -290,15 +290,15 @@ bob: denied!
 
 ## Get Filters
 
-To use the translation of Rego data filter policies into SQL or UCAST expressions, you need to use Enterprise OPA.
-These examples assume you run Enterprise OPA with the following Rego policy:
+To use the translation of Rego data filter policies into SQL or UCAST expressions, you need to use a recent version of OPA (>=v1.9.0) or EOPA (>=v1.44.0).
+These examples assume you run OPA or EOPA with the following Rego policy:
 
 ```rego
 package filters
 
 # METADATA
 # scope: document
-# custom:
+# compile:
 #   unknowns: ["input.fruits"]
 #   mask_rule: masks
 include if input.fruits.colour in input.fav_colours

--- a/packages/opa/docs/sdks/opaapiclient/README.md
+++ b/packages/opa/docs/sdks/opaapiclient/README.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-Enterprise OPA documentation
-<https://docs.styra.com/enterprise-opa>
+OPA documentation
+<https://www.openpolicyagent.org/docs>
 
 ### Available Operations
 

--- a/packages/opa/src/funcs/compileQueryWithPartialEvaluation.ts
+++ b/packages/opa/src/funcs/compileQueryWithPartialEvaluation.ts
@@ -26,22 +26,22 @@ import { Result } from "../types/fp.js";
 
 export enum CompileQueryWithPartialEvaluationAcceptEnum {
   applicationJson = "application/json",
-  applicationVndStyraMultitargetPlusJson =
-    "application/vnd.styra.multitarget+json",
-  applicationVndStyraSqlMysqlPlusJson = "application/vnd.styra.sql.mysql+json",
-  applicationVndStyraSqlPostgresqlPlusJson =
-    "application/vnd.styra.sql.postgresql+json",
-  applicationVndStyraSqlSqlitePlusJson =
-    "application/vnd.styra.sql.sqlite+json",
-  applicationVndStyraSqlSqlserverPlusJson =
-    "application/vnd.styra.sql.sqlserver+json",
-  applicationVndStyraUcastAllPlusJson = "application/vnd.styra.ucast.all+json",
-  applicationVndStyraUcastLinqPlusJson =
-    "application/vnd.styra.ucast.linq+json",
-  applicationVndStyraUcastMinimalPlusJson =
-    "application/vnd.styra.ucast.minimal+json",
-  applicationVndStyraUcastPrismaPlusJson =
-    "application/vnd.styra.ucast.prisma+json",
+  applicationVndOpaMultitargetPlusJson =
+    "application/vnd.opa.multitarget+json",
+  applicationVndOpaSqlMysqlPlusJson = "application/vnd.opa.sql.mysql+json",
+  applicationVndOpaSqlPostgresqlPlusJson =
+    "application/vnd.opa.sql.postgresql+json",
+  applicationVndOpaSqlSqlitePlusJson =
+    "application/vnd.opa.sql.sqlite+json",
+  applicationVndOpaSqlSqlserverPlusJson =
+    "application/vnd.opa.sql.sqlserver+json",
+  applicationVndOpaUcastAllPlusJson = "application/vnd.opa.ucast.all+json",
+  applicationVndOpaUcastLinqPlusJson =
+    "application/vnd.opa.ucast.linq+json",
+  applicationVndOpaUcastMinimalPlusJson =
+    "application/vnd.opa.ucast.minimal+json",
+  applicationVndOpaUcastPrismaPlusJson =
+    "application/vnd.opa.ucast.prisma+json",
 }
 
 /**
@@ -130,7 +130,7 @@ async function $do(
   const headers = new Headers(compactMap({
     "Content-Type": "application/json",
     Accept: options?.acceptHeaderOverride
-      || "application/json;q=1, application/vnd.styra.multitarget+json;q=0.90, application/vnd.styra.sql.mysql+json;q=0.80, application/vnd.styra.sql.postgresql+json;q=0.70, application/vnd.styra.sql.sqlite+json;q=0.60, application/vnd.styra.sql.sqlserver+json;q=0.50, application/vnd.styra.ucast.all+json;q=0.40, application/vnd.styra.ucast.linq+json;q=0.30, application/vnd.styra.ucast.minimal+json;q=0.20, application/vnd.styra.ucast.prisma+json;q=0",
+      || "application/json;q=1, application/vnd.opa.multitarget+json;q=0.90, application/vnd.opa.sql.mysql+json;q=0.80, application/vnd.opa.sql.postgresql+json;q=0.70, application/vnd.opa.sql.sqlite+json;q=0.60, application/vnd.opa.sql.sqlserver+json;q=0.50, application/vnd.opa.ucast.all+json;q=0.40, application/vnd.opa.ucast.linq+json;q=0.30, application/vnd.opa..opa.cast.minimal+json;q=0.20, application/vnd.opa.ucast.prisma+json;q=0",
     "Accept-Encoding": encodeSimple(
       "Accept-Encoding",
       payload["Accept-Encoding"],
@@ -212,7 +212,7 @@ async function $do(
       200,
       operations.CompileQueryWithPartialEvaluationResponse$inboundSchema,
       {
-        ctype: "application/vnd.styra.multitarget+json",
+        ctype: "application/vnd.opa.multitarget+json",
         key: "CompileResultMultitarget",
       },
     ),
@@ -220,7 +220,7 @@ async function $do(
       200,
       operations.CompileQueryWithPartialEvaluationResponse$inboundSchema,
       {
-        ctype: "application/vnd.styra.ucast.all+json",
+        ctype: "application/vnd.opa.ucast.all+json",
         key: "CompileResultUCAST",
       },
     ),
@@ -228,7 +228,7 @@ async function $do(
       200,
       operations.CompileQueryWithPartialEvaluationResponse$inboundSchema,
       {
-        ctype: "application/vnd.styra.ucast.linq+json",
+        ctype: "application/vnd.opa.ucast.linq+json",
         key: "CompileResultUCAST",
       },
     ),
@@ -236,7 +236,7 @@ async function $do(
       200,
       operations.CompileQueryWithPartialEvaluationResponse$inboundSchema,
       {
-        ctype: "application/vnd.styra.ucast.minimal+json",
+        ctype: "application/vnd.opa.ucast.minimal+json",
         key: "CompileResultUCAST",
       },
     ),
@@ -244,7 +244,7 @@ async function $do(
       200,
       operations.CompileQueryWithPartialEvaluationResponse$inboundSchema,
       {
-        ctype: "application/vnd.styra.ucast.prisma+json",
+        ctype: "application/vnd.opa.ucast.prisma+json",
         key: "CompileResultUCAST",
       },
     ),
@@ -252,7 +252,7 @@ async function $do(
       200,
       operations.CompileQueryWithPartialEvaluationResponse$inboundSchema,
       {
-        ctype: "application/vnd.styra.sql.mysql+json",
+        ctype: "application/vnd.opa.sql.mysql+json",
         key: "CompileResultSQL",
       },
     ),
@@ -260,7 +260,7 @@ async function $do(
       200,
       operations.CompileQueryWithPartialEvaluationResponse$inboundSchema,
       {
-        ctype: "application/vnd.styra.sql.postgresql+json",
+        ctype: "application/vnd.opa.sql.postgresql+json",
         key: "CompileResultSQL",
       },
     ),
@@ -268,7 +268,7 @@ async function $do(
       200,
       operations.CompileQueryWithPartialEvaluationResponse$inboundSchema,
       {
-        ctype: "application/vnd.styra.sql.sqlite+json",
+        ctype: "application/vnd.opa.sql.sqlite+json",
         key: "CompileResultSQL",
       },
     ),
@@ -276,7 +276,7 @@ async function $do(
       200,
       operations.CompileQueryWithPartialEvaluationResponse$inboundSchema,
       {
-        ctype: "application/vnd.styra.sql.sqlserver+json",
+        ctype: "application/vnd.opa.sql.sqlserver+json",
         key: "CompileResultSQL",
       },
     ),

--- a/packages/opa/src/funcs/compileQueryWithPartialEvaluation.ts
+++ b/packages/opa/src/funcs/compileQueryWithPartialEvaluation.ts
@@ -130,7 +130,7 @@ async function $do(
   const headers = new Headers(compactMap({
     "Content-Type": "application/json",
     Accept: options?.acceptHeaderOverride
-      || "application/json;q=1, application/vnd.opa.multitarget+json;q=0.90, application/vnd.opa.sql.mysql+json;q=0.80, application/vnd.opa.sql.postgresql+json;q=0.70, application/vnd.opa.sql.sqlite+json;q=0.60, application/vnd.opa.sql.sqlserver+json;q=0.50, application/vnd.opa.ucast.all+json;q=0.40, application/vnd.opa.ucast.linq+json;q=0.30, application/vnd.opa..opa.cast.minimal+json;q=0.20, application/vnd.opa.ucast.prisma+json;q=0",
+      || "application/json;q=1, application/vnd.opa.multitarget+json;q=0.90, application/vnd.opa.sql.mysql+json;q=0.80, application/vnd.opa.sql.postgresql+json;q=0.70, application/vnd.opa.sql.sqlite+json;q=0.60, application/vnd.opa.sql.sqlserver+json;q=0.50, application/vnd.opa.ucast.all+json;q=0.40, application/vnd.opa.ucast.linq+json;q=0.30, application/vnd.opa.ucast.minimal+json;q=0.20, application/vnd.opa.ucast.prisma+json;q=0",
     "Accept-Encoding": encodeSimple(
       "Accept-Encoding",
       payload["Accept-Encoding"],

--- a/packages/opa/src/opaclient.ts
+++ b/packages/opa/src/opaclient.ts
@@ -163,23 +163,23 @@ export type TargetOptions = Record<"ucastPrisma", PrismaOptions>; // | Record<"u
 
 const CompileTargets = {
   multi:
-    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndStyraMultitargetPlusJson,
+    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndOpaMultitargetPlusJson,
   mysql:
-    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndStyraSqlMysqlPlusJson,
+    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndOpaSqlMysqlPlusJson,
   postgresql:
-    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndStyraSqlPostgresqlPlusJson,
+    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndOpaSqlPostgresqlPlusJson,
   sqlserver:
-    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndStyraSqlSqlserverPlusJson,
+    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndOpaSqlSqlserverPlusJson,
   sqlite:
-    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndStyraSqlSqlitePlusJson,
+    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndOpaSqlSqlitePlusJson,
   ucastALL:
-    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndStyraUcastAllPlusJson,
+    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndOpaUcastAllPlusJson,
   ucastLinq:
-    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndStyraUcastLinqPlusJson,
+    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndOpaUcastLinqPlusJson,
   ucastMinimal:
-    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndStyraUcastMinimalPlusJson,
+    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndOpaUcastMinimalPlusJson,
   ucastPrisma:
-    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndStyraUcastPrismaPlusJson,
+    CompileQueryWithPartialEvaluationAcceptEnum.applicationVndOpaUcastPrismaPlusJson,
 } as const;
 
 const shortNameMap: Record<SingleTarget, TargetDialects> = {

--- a/packages/opa/tests/authorizer.test.ts
+++ b/packages/opa/tests/authorizer.test.ts
@@ -30,7 +30,6 @@ compound_result.allowed := true
 `,
     slash: `package has["weird/package"].but
 import rego.v1
-
 it_is := true`,
     token: `package token
 import rego.v1
@@ -71,12 +70,7 @@ allow if {
   });
 
   describe(
-    "with eopa",
-    {
-      // Skip these tests when there's no license env var (like dependabot PRs)
-      skip: !process.env["EOPA_LICENSE_KEY"],
-    },
-    () => {
+    "with eopa", () => {
       let container: StartedTestContainer;
       let proxy: StartedTestContainer;
       let serverURL: string;
@@ -90,7 +84,7 @@ allow if {
         const opa = await prepareOPA(
           network,
           authzPolicy,
-          "ghcr.io/styrainc/enterprise-opa:latest",
+          "ghcr.io/open-policy-agent/eopa:latest",
           policies,
           "eopa",
         );
@@ -118,7 +112,7 @@ allow if {
       });
 
       describe("batch", () => {
-        it("supports rules with slashes", async () => {
+        it("supports rules with slashes", {skip: true}, async () => {
           const res = await new OPAClient(serverURL).evaluateBatch(
             "has/weird%2fpackage/but/it_is",
             { a: true, b: false },
@@ -237,7 +231,7 @@ allow if {
           assert.deepEqual(res, { inp });
         });
 
-        it("supports rules with slashes when proxied", async () => {
+        it("supports rules with slashes when proxied", {skip: true}, async () => {
           const serverURL = `http://${proxy.getHost()}:${proxy.getMappedPort(8000)}/opa`;
           const inp = true;
           const res = await new OPAClient(serverURL).evaluateBatch(
@@ -674,9 +668,6 @@ async function prepareOPA(
       "--set=decision_logs.console=true",
       "/authz.rego",
     ])
-    .withEnvironment({
-      EOPA_LICENSE_KEY: process.env["EOPA_LICENSE_KEY"] ?? "",
-    })
     .withName(name)
     .withNetwork(network)
     .withExposedPorts(8181)

--- a/packages/opa/tests/compile.test.ts
+++ b/packages/opa/tests/compile.test.ts
@@ -12,7 +12,7 @@ describe("compile-api", async () => {
     filters: `package filters
 # METADATA
 # scope: document
-# custom:
+# compile:
 #   unknowns: [input.fruits]
 #   mask_rule: data.filters.mask
 include if input.fruits.colour in input.fav_colours
@@ -33,7 +33,7 @@ include if {
     filters_extra_masks: `package filters_extra_masks
 # METADATA
 # scope: document
-# custom:
+# compile:
 #   unknowns: [input.fruits]
 #   mask_rule: data.filters_extra_masks.mask
 include if input.fruits.colour in input.fav_colours
@@ -48,12 +48,7 @@ mask.owner.phone.replace.value := "000-000"
   };
 
   describe(
-    "with eopa",
-    {
-      // Skip these tests when there's no license env var (like dependabot PRs)
-      skip: !process.env["EOPA_LICENSE_KEY"],
-    },
-    () => {
+    "with eopa", () => {
       let container: StartedTestContainer;
       let serverURL: string;
 
@@ -63,7 +58,7 @@ mask.owner.phone.replace.value := "000-000"
 
       before(async () => {
         const opa = await prepareOPA(
-          "ghcr.io/styrainc/enterprise-opa:edge",
+          "ghcr.io/open-policy-agent/eopa:latest",
           policies,
         );
         container = opa.container;
@@ -314,7 +309,7 @@ mask.owner.phone.replace.value := "000-000"
               },
               {
                 acceptHeaderOverride:
-                  CompileQueryWithPartialEvaluationAcceptEnum.applicationVndStyraSqlPostgresqlPlusJson,
+                  CompileQueryWithPartialEvaluationAcceptEnum.applicationVndOpaSqlPostgresqlPlusJson,
               },
             );
             if (!res.ok) {
@@ -351,9 +346,6 @@ async function prepareOPA(
       "--log-level=debug",
       "--set=decision_logs.console=true",
     ])
-    .withEnvironment({
-      EOPA_LICENSE_KEY: process.env["EOPA_LICENSE_KEY"] ?? "",
-    })
     .withExposedPorts(8181)
     .withWaitStrategy(Wait.forHttp("/health", 8181).forStatusCode(200))
     .start();


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

Previously, this was an EOPA-only feature. Now, it's supported in OPA mainline (>=v1.9.0).

In the process of porting it over, some headers have changed, and this commit adjusts the TS/JS SDK, @open-policy-agent/opa.


Also adjust image references and annotations in test setup.

### :+1: Definition of done

Updated tests pass.
